### PR TITLE
Preserve GET params in app list view

### DIFF
--- a/nextcloudappstore/core/static/assets/css/accordion.css
+++ b/nextcloudappstore/core/static/assets/css/accordion.css
@@ -74,7 +74,7 @@
 }
 
 .accordion-item .accordion-item .accordion-title h5:after {
-    content: ' \e252';
+    content: '\e252';
     font-family: 'Glyphicons Halflings';
     float: right;
     position: relative;

--- a/nextcloudappstore/core/static/assets/css/style.css
+++ b/nextcloudappstore/core/static/assets/css/style.css
@@ -223,6 +223,11 @@ form .text-danger {
     text-decoration: none;
 }
 
+.search-results-title {
+    margin-top: 0;
+    margin-bottom: 30px;
+}
+
 .app-list-container img {
     max-width: 100%;
 }

--- a/nextcloudappstore/core/templates/app/base.html
+++ b/nextcloudappstore/core/templates/app/base.html
@@ -8,27 +8,11 @@
         {% if categories %}
         <ul id="sidebar" class="nav nav-pills nav-stacked">
             <li class="{% if cat.id == current_category.id and not object %}active{% endif %}">
-                {% if ordering_url_args and filter_url_args %}
-                    <a href="{% url 'home' %}?{{ ordering_url_args }}&{{ filter_url_args }}">{% trans 'All Apps' %}</a>
-                {% elif ordering_url_args %}
-                    <a href="{% url 'home' %}?{{ ordering_url_args }}">{% trans 'All Apps' %}</a>
-                {% elif filter_url_args %}
-                    <a href="{% url 'home' %}?{{ filter_url_args }}">{% trans 'All Apps' %}</a>
-                {% else %}
-                    <a href="{% url 'home' %}">{% trans 'All Apps' %}</a>
-                {% endif %}
+                <a href="{% url 'home' %}{% if get_arg_url_strings.filters_ordering %}?{{ get_arg_url_strings.filters_ordering }}{% endif %}">{% trans 'All Apps' %}</a>
             </li>
             {% for cat in categories %}
             <li class="{% if cat.id == current_category.id %}active{% endif %}">
-                {% if ordering_url_args and filter_url_args %}
-                    <a href="{% url 'category-app-list' cat.id %}?{{ ordering_url_args }}&{{ filter_url_args }}">{{ cat.name }}</a>
-                {% elif ordering_url_args %}
-                    <a href="{% url 'category-app-list' cat.id %}?{{ ordering_url_args }}">{{ cat.name }}</a>
-                {% elif filter_url_args %}
-                    <a href="{% url 'category-app-list' cat.id %}?{{ filter_url_args }}">{{ cat.name }}</a>
-                {% else %}
-                    <a href="{% url 'category-app-list' cat.id %}">{{ cat.name }}</a>
-                {% endif %}
+                <a href="{% url 'category-app-list' cat.id %}{% if get_arg_url_strings.filters_ordering %}?{{ get_arg_url_strings.filters_ordering }}{% endif %}">{{ cat.name }}</a>
             {% endfor %}
             </li>
         </ul>

--- a/nextcloudappstore/core/templates/app/base.html
+++ b/nextcloudappstore/core/templates/app/base.html
@@ -8,11 +8,11 @@
         {% if categories %}
         <ul id="sidebar" class="nav nav-pills nav-stacked">
             <li class="{% if cat.id == current_category.id and not object %}active{% endif %}">
-                <a href="{% url 'home' %}{% if get_arg_url_strings.filters_ordering %}?{{ get_arg_url_strings.filters_ordering }}{% endif %}">{% trans 'All Apps' %}</a>
+                <a href="{% url 'home' %}{% if url_params.filters_ordering %}?{{ url_params.filters_ordering }}{% endif %}">{% trans 'All Apps' %}</a>
             </li>
             {% for cat in categories %}
             <li class="{% if cat.id == current_category.id %}active{% endif %}">
-                <a href="{% url 'category-app-list' cat.id %}{% if get_arg_url_strings.filters_ordering %}?{{ get_arg_url_strings.filters_ordering }}{% endif %}">{{ cat.name }}</a>
+                <a href="{% url 'category-app-list' cat.id %}{% if url_params.filters_ordering %}?{{ url_params.filters_ordering }}{% endif %}">{{ cat.name }}</a>
             {% endfor %}
             </li>
         </ul>

--- a/nextcloudappstore/core/templates/app/base.html
+++ b/nextcloudappstore/core/templates/app/base.html
@@ -8,12 +8,29 @@
         {% if categories %}
         <ul id="sidebar" class="nav nav-pills nav-stacked">
             <li class="{% if cat.id == current_category.id and not object %}active{% endif %}">
-                <a href="{% url 'home' %}">{% trans 'All Apps' %}</a>
+                {% if ordering_url_args and filter_url_args %}
+                    <a href="{% url 'home' %}?{{ ordering_url_args }}&{{ filter_url_args }}">{% trans 'All Apps' %}</a>
+                {% elif ordering_url_args %}
+                    <a href="{% url 'home' %}?{{ ordering_url_args }}">{% trans 'All Apps' %}</a>
+                {% elif filter_url_args %}
+                    <a href="{% url 'home' %}?{{ filter_url_args }}">{% trans 'All Apps' %}</a>
+                {% else %}
+                    <a href="{% url 'home' %}">{% trans 'All Apps' %}</a>
+                {% endif %}
             </li>
             {% for cat in categories %}
             <li class="{% if cat.id == current_category.id %}active{% endif %}">
-                <a href="{% url 'category-app-list' cat.id %}">{{ cat.name }}</a></li>
+                {% if ordering_url_args and filter_url_args %}
+                    <a href="{% url 'category-app-list' cat.id %}?{{ ordering_url_args }}&{{ filter_url_args }}">{{ cat.name }}</a>
+                {% elif ordering_url_args %}
+                    <a href="{% url 'category-app-list' cat.id %}?{{ ordering_url_args }}">{{ cat.name }}</a>
+                {% elif filter_url_args %}
+                    <a href="{% url 'category-app-list' cat.id %}?{{ filter_url_args }}">{{ cat.name }}</a>
+                {% else %}
+                    <a href="{% url 'category-app-list' cat.id %}">{{ cat.name }}</a>
+                {% endif %}
             {% endfor %}
+            </li>
         </ul>
         {% endif %}
     </div>

--- a/nextcloudappstore/core/templates/app/list.html
+++ b/nextcloudappstore/core/templates/app/list.html
@@ -12,22 +12,22 @@
 {% if search_query %}
     <div class="col-lg-6">
         {% if search_query and current_category %}
-            <h2 class="search-results-title">{% blocktrans with cat=current_category q=search_query%}Search results for "{{ q }}" in {{ cat }}{% endblocktrans %}</h2>
+            <h2 class="search-results-title">{% blocktrans with category=current_category query=search_query %}Search results for "{{ query }}" in {{ category }}{% endblocktrans %}</h2>
         {% elif search_query %}
-            <h2 class="search-results-title">{% blocktrans with q=search_query%}Search results for "{{ q }}"{% endblocktrans %}</h2>
+            <h2 class="search-results-title">{% blocktrans with query=search_query %}Search results for "{{ query }}"{% endblocktrans %}</h2>
         {% endif %}
     </div>
 {% endif %}
 
 <div class="row">
     <ul class="nav-tabs nav sorting">
-        <li role="presentation" class="{% if not request.GET.order_by or request.GET.order_by == 'last_modified' %}active{% endif %}"><a href="{{ request.url }}?order_by=last_modified&ordering=desc{% if get_arg_url_strings.search_filters %}&{{ get_arg_url_strings.search_filters }}{% endif %}">{% trans 'Latest' %}</a></li>
+        <li role="presentation" class="{% if not request.GET.order_by or request.GET.order_by == 'last_modified' %}active{% endif %}"><a href="{{ request.url }}?order_by=last_modified&amp;ordering=desc{% if url_params.search_filters %}&amp;{{ url_params.search_filters }}{% endif %}">{% trans 'Latest' %}</a></li>
         {% if request.GET.order_by == 'name' and request.GET.ordering == 'asc' %}
-        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url }}?order_by=name&ordering=desc{% if get_arg_url_strings.search_filters %}&{{ get_arg_url_strings.search_filters }}{% endif %}"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
+        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url }}?order_by=name&amp;ordering=desc{% if url_params.search_filters %}&amp;{{ url_params.search_filters }}{% endif %}"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
         {% elif request.GET.order_by == 'name' and request.GET.ordering == 'desc' %}
-        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url }}?order_by=name&ordering=asc{% if get_arg_url_strings.search_filters %}&{{ get_arg_url_strings.search_filters }}{% endif %}"><span class="glyphicon glyphicon-triangle-top" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
+        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url }}?order_by=name&amp;ordering=asc{% if url_params.search_filters %}&amp;{{ url_params.search_filters }}{% endif %}"><span class="glyphicon glyphicon-triangle-top" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
         {% else %}
-        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url }}?order_by=name&ordering=asc{% if get_arg_url_strings.search_filters %}&{{ get_arg_url_strings.search_filters }}{% endif %}"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
+        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url }}?order_by=name&amp;ordering=asc{% if url_params.search_filters %}&amp;{{ url_params.search_filters }}{% endif %}"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
         {% endif %}
         <li role="presentation" class="filters">
             <form method="get" action="{{ request.path }}" name="filter-form" id="filter-form">
@@ -64,9 +64,9 @@
 {% empty %}
     <div class="col-lg-6 app-list-container">
         {% if search_query and current_category %}
-            <p class="message no-apps-found">{% blocktrans with cat=current_category.name %}No apps found for search "<em>{{ search_query }}</em>" in {{ cat }}.{% endblocktrans %}</p>
+            <p class="message no-apps-found">{% blocktrans with category=current_category.name query=search_query %}No apps found for search "<em>{{ query }}</em>" in {{ category }}.{% endblocktrans %}</p>
         {% elif search_query %}
-            <p class="message no-apps-found">{% blocktrans %}No apps found for search "<em>{{ search_query }}</em>".{% endblocktrans %}</p>
+            <p class="message no-apps-found">{% blocktrans with query=search_query %}No apps found for search "<em>{{ query }}</em>".{% endblocktrans %}</p>
         {% endif %}
     </div>
 {% endfor %}

--- a/nextcloudappstore/core/templates/app/list.html
+++ b/nextcloudappstore/core/templates/app/list.html
@@ -21,13 +21,13 @@
 
 <div class="row">
     <ul class="nav-tabs nav sorting">
-        <li role="presentation" class="{% if not request.GET.order_by or request.GET.order_by == 'last_modified' %}active{% endif %}"><a href="{{ request.url  }}?order_by=last_modified&ordering=desc{% if filter_url_args %}&{{ filter_url_args }}{% endif %}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}">{% trans 'Latest' %}</a></li>
+        <li role="presentation" class="{% if not request.GET.order_by or request.GET.order_by == 'last_modified' %}active{% endif %}"><a href="{{ request.url }}?order_by=last_modified&ordering=desc{% if get_arg_url_strings.search_filters %}&{{ get_arg_url_strings.search_filters }}{% endif %}">{% trans 'Latest' %}</a></li>
         {% if request.GET.order_by == 'name' and request.GET.ordering == 'asc' %}
-        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url  }}?order_by=name&ordering=desc{% if filter_url_args %}&{{ filter_url_args }}{% endif %}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
+        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url }}?order_by=name&ordering=desc{% if get_arg_url_strings.search_filters %}&{{ get_arg_url_strings.search_filters }}{% endif %}"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
         {% elif request.GET.order_by == 'name' and request.GET.ordering == 'desc' %}
-        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url  }}?order_by=name&ordering=asc{% if filter_url_args %}&{{ filter_url_args }}{% endif %}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}"><span class="glyphicon glyphicon-triangle-top" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
+        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url }}?order_by=name&ordering=asc{% if get_arg_url_strings.search_filters %}&{{ get_arg_url_strings.search_filters }}{% endif %}"><span class="glyphicon glyphicon-triangle-top" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
         {% else %}
-        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url  }}?order_by=name&ordering=asc{% if filter_url_args %}&{{ filter_url_args }}{% endif %}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
+        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url }}?order_by=name&ordering=asc{% if get_arg_url_strings.search_filters %}&{{ get_arg_url_strings.search_filters }}{% endif %}"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
         {% endif %}
         <li role="presentation" class="filters">
             <form method="get" action="{{ request.path }}" name="filter-form" id="filter-form">
@@ -38,7 +38,7 @@
                     <label for="myapps-checkbox">{% trans 'My apps' %}</label>
                 {% endif %}
 
-                {# Include all non-filter GET arguments that should persist after applying a filter. #}
+                {# Include all GET arguments that should be preserved when applying a filter. #}
                 {% if request.GET.search %}<input type="hidden" name="search" value="{{ request.GET.search }}">{% endif %}
                 {% if request.GET.order_by %}<input type="hidden" name="order_by" value="{{ request.GET.order_by }}">{% endif %}
                 {% if request.GET.ordering %}<input type="hidden" name="ordering" value="{{ request.GET.ordering }}">{% endif %}

--- a/nextcloudappstore/core/templates/app/list.html
+++ b/nextcloudappstore/core/templates/app/list.html
@@ -8,15 +8,26 @@
 {% endblock %}
 
 {% block apps %}
+
+{% if search_query %}
+    <div class="col-lg-6">
+        {% if search_query and current_category %}
+            <h2 class="search-results-title">{% blocktrans with cat=current_category q=search_query%}Search results for "{{ q }}" in {{ cat }}{% endblocktrans %}</h2>
+        {% elif search_query %}
+            <h2 class="search-results-title">{% blocktrans with q=search_query%}Search results for "{{ q }}"{% endblocktrans %}</h2>
+        {% endif %}
+    </div>
+{% endif %}
+
 <div class="row">
     <ul class="nav-tabs nav sorting">
-        <li role="presentation" class="{% if not request.GET.order_by or request.GET.order_by == 'last_modified' %}active{% endif %}"><a href="{{ request.url  }}?order_by=last_modified&ordering=desc">{% trans 'Latest' %}</a></li>
+        <li role="presentation" class="{% if not request.GET.order_by or request.GET.order_by == 'last_modified' %}active{% endif %}"><a href="{{ request.url  }}?order_by=last_modified&ordering=desc{% if filter_url_args %}&{{ filter_url_args }}{% endif %}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}">{% trans 'Latest' %}</a></li>
         {% if request.GET.order_by == 'name' and request.GET.ordering == 'asc' %}
-        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url  }}?order_by=name&ordering=desc"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
+        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url  }}?order_by=name&ordering=desc{% if filter_url_args %}&{{ filter_url_args }}{% endif %}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
         {% elif request.GET.order_by == 'name' and request.GET.ordering == 'desc' %}
-        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url  }}?order_by=name&ordering=asc"><span class="glyphicon glyphicon-triangle-top" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
+        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url  }}?order_by=name&ordering=asc{% if filter_url_args %}&{{ filter_url_args }}{% endif %}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}"><span class="glyphicon glyphicon-triangle-top" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
         {% else %}
-        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url  }}?order_by=name&ordering=asc"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
+        <li role="presentation" class="{% if request.GET.order_by == 'name' %}active{% endif %}"><a href="{{ request.url  }}?order_by=name&ordering=asc{% if filter_url_args %}&{{ filter_url_args }}{% endif %}{% if request.GET.search %}&search={{ request.GET.search }}{% endif %}"><span class="glyphicon glyphicon-triangle-bottom" aria-hidden="true"></span> {% trans 'Alphabetical' %}</a></li>
         {% endif %}
         <li role="presentation" class="filters">
             <form method="get" action="{{ request.path }}" name="filter-form" id="filter-form">
@@ -26,6 +37,9 @@
                     <input type="checkbox" class="auto-submit" id="myapps-checkbox" name="maintainer" value="{{ request.user.username }}" {% if request.GET.maintainer == request.user.username %}checked{% endif %}>
                     <label for="myapps-checkbox">{% trans 'My apps' %}</label>
                 {% endif %}
+
+                {# Include all non-filter GET arguments that should persist after applying a filter. #}
+                {% if request.GET.search %}<input type="hidden" name="search" value="{{ request.GET.search }}">{% endif %}
                 {% if request.GET.order_by %}<input type="hidden" name="order_by" value="{{ request.GET.order_by }}">{% endif %}
                 {% if request.GET.ordering %}<input type="hidden" name="ordering" value="{{ request.GET.ordering }}">{% endif %}
             </form>

--- a/nextcloudappstore/core/templates/nav.html
+++ b/nextcloudappstore/core/templates/nav.html
@@ -17,6 +17,11 @@
                                 {% endif %}"
                    class="form-control search-box">
             <span class="glyphicon glyphicon-search form-control-feedback" aria-hidden="true"></span>
+
+            {# Include all GET arguments that should be preserved when searching. #}
+            {% if request.GET.order_by %}<input type="hidden" name="order_by" value="{{ request.GET.order_by }}">{% endif %}
+            {% if request.GET.ordering %}<input type="hidden" name="ordering" value="{{ request.GET.ordering }}">{% endif %}
+
             <input type="submit" value="{% trans 'Search' %}" class="search-button">
         </form>
     </div>

--- a/nextcloudappstore/core/views.py
+++ b/nextcloudappstore/core/views.py
@@ -1,5 +1,5 @@
 from functools import reduce
-
+from urllib.parse import urlencode
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
@@ -10,7 +10,6 @@ from django.utils.translation import get_language, get_language_info
 from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 from nextcloudappstore.core.models import App, Category
-from urllib.parse import urlencode
 
 
 def app_description(request, id):

--- a/nextcloudappstore/core/views.py
+++ b/nextcloudappstore/core/views.py
@@ -91,17 +91,17 @@ class CategoryAppListView(ListView):
             context['current_category'] = Category.objects.get(id=category_id)
         if self.search_terms:
             context['search_query'] = ' '.join(self.search_terms)
-        context['get_arg_url_strings'] = self.get_arg_url_strings
+        context['url_params'] = self.url_params
         return context
 
     @cached_property
-    def get_arg_url_strings(self):
-        """URL encoded strings with the GET args of the last request.
+    def url_params(self):
+        """URL encoded strings with the GET params of the last request.
 
-        Intended for preserving GET arguments upon clicking a link by including
+        Intended for preserving GET params upon clicking a link by including
         one (and only one) of these strings in the "href" attribute.
 
-        The GET params are divided into three groups: search, filters and
+        The parameters are divided into three groups: search, filters and
         ordering. In addition to these three, the returned dict also contains
         some combinations of them, as specified by the dict keys.
 
@@ -110,26 +110,26 @@ class CategoryAppListView(ListView):
         :return dict with URL encoded strings.
         """
 
-        search = self._get_args_as_url_string('search')
-        filters = self._get_args_as_url_string('featured', 'maintainer')
-        ordering = self._get_args_as_url_string('order_by', 'ordering')
+        search = self._url_params_str('search')
+        filters = self._url_params_str('featured', 'maintainer')
+        ordering = self._url_params_str('order_by', 'ordering')
 
         return {
             'search': search,
             'filters': filters,
             'ordering': ordering,
-            'filters_ordering': self._combine_arg_strings(filters, ordering),
-            'search_filters': self._combine_arg_strings(search, filters),
+            'search_filters': self._join_url_params_strs(search, filters),
+            'filters_ordering': self._join_url_params_strs(filters, ordering),
         }
 
-    def _get_args_as_url_string(self, *arg_names):
-        args = map(lambda arg: (arg, self.request.GET.get(arg, '')), arg_names)
-        filtered_dict = dict(filter(lambda a: a[1], args))
-        return urlencode(filtered_dict)
+    def _url_params_str(self, *params):
+        args = map(lambda param: (param, self.request.GET.get(param, '')),
+                   params)
+        present_args = filter(lambda a: a[1], args)
+        return urlencode(dict(present_args))
 
-    def _combine_arg_strings(self, *strings):
-        return reduce(lambda str, add: str+'&'+add, filter(None, strings), '')\
-            .lstrip('&')
+    def _join_url_params_strs(self, *strings):
+        return '&'.join(strings).lstrip('&')
 
     @cached_property
     def search_terms(self):

--- a/nextcloudappstore/core/views.py
+++ b/nextcloudappstore/core/views.py
@@ -129,7 +129,7 @@ class CategoryAppListView(ListView):
         return urlencode(dict(present_args))
 
     def _join_url_params_strs(self, *strings):
-        return '&'.join(strings).lstrip('&')
+        return '&'.join(filter(None, strings))
 
     @cached_property
     def search_terms(self):

--- a/nextcloudappstore/core/views.py
+++ b/nextcloudappstore/core/views.py
@@ -1,3 +1,5 @@
+from functools import reduce
+
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
@@ -8,6 +10,7 @@ from django.utils.translation import get_language, get_language_info
 from django.views.generic.detail import DetailView
 from django.views.generic.list import ListView
 from nextcloudappstore.core.models import App, Category
+from urllib.parse import urlencode
 
 
 def app_description(request, id):
@@ -89,6 +92,21 @@ class CategoryAppListView(ListView):
             context['current_category'] = Category.objects.get(id=category_id)
         if self.search_terms:
             context['search_query'] = ' '.join(self.search_terms)
+
+        filter_url_args = {
+            'featured': self.request.GET.get('featured', ''),
+            'maintainer': self.request.GET.get('maintainer', ''),
+        }
+        filter_url_args = dict(filter(lambda a: a[1], filter_url_args.items()))
+        context['filter_url_args'] = urlencode(filter_url_args)
+
+        ordering_url_args = {
+            'order_by': self.request.GET.get('order_by', ''),
+            'ordering': self.request.GET.get('ordering', ''),
+        }
+        ordering_url_args = dict(filter(lambda a: a[1], ordering_url_args.items()))
+        context['ordering_url_args'] = urlencode(ordering_url_args)
+
         return context
 
     @cached_property


### PR DESCRIPTION
#99 

- Preserve GET params according to the table below.
- Clearly indicate to the user when they are browsing search results.

P=Preserve, D=Discard

Change | Search | Filters | Ordering | Category
--- | --- | --- | --- | ---
Search | - | D | P | P
Filters | P | - | P | P
Ordering | P | P | - | P
Category | D | P | P | -

In short, everything is preserved except search when changing category and filters when searching. The former provides a natural way to discard search results (it would be rather difficult otherwise). The latter is because the search box gives no indication that the search is limited by the filters. I think that's something for a future advanced search. However, even now it is possible to apply filters to search results once they are presented to you.