### PR TITLE
tweak display of required PHP version in release view

### DIFF
--- a/nextcloudappstore/core/templates/app/base.html
+++ b/nextcloudappstore/core/templates/app/base.html
@@ -13,8 +13,8 @@
             {% for cat in categories %}
             <li class="{% if cat.id == current_category.id %}active{% endif %}">
                 <a href="{% url 'category-app-list' cat.id %}{% if url_params.filters_ordering %}?{{ url_params.filters_ordering }}{% endif %}">{{ cat.name }}</a>
-            {% endfor %}
             </li>
+            {% endfor %}
         </ul>
         {% endif %}
     </div>

--- a/nextcloudappstore/core/templates/app/releases.html
+++ b/nextcloudappstore/core/templates/app/releases.html
@@ -61,7 +61,7 @@
                                         </tr>
                                         {% endif %}
                                         <tr><td>{% trans 'Minimum integer bits' %}</td><td>{{ release.min_int_size }}</td></tr>
-                                        {% if release.php_version_spec %}
+                                        {% if release.php_version_spec|version_spec %}
                                         <tr><td>{% trans 'PHP' %}</td><td>{{ release.php_version_spec|version_spec }}</td></tr>
                                         {% endif %}
                                         {% if release.phpextensiondependencies.all %}

--- a/nextcloudappstore/core/templates/app/releases.html
+++ b/nextcloudappstore/core/templates/app/releases.html
@@ -61,7 +61,9 @@
                                         </tr>
                                         {% endif %}
                                         <tr><td>{% trans 'Minimum integer bits' %}</td><td>{{ release.min_int_size }}</td></tr>
+                                        {% if release.php_version_spec %}
                                         <tr><td>{% trans 'PHP' %}</td><td>{{ release.php_version_spec|version_spec }}</td></tr>
+                                        {% endif %}
                                         {% if release.phpextensiondependencies.all %}
                                         <tr>
                                             <td>{% trans 'PHP extensions' %}</td>

--- a/nextcloudappstore/core/templatetags/version_spec.py
+++ b/nextcloudappstore/core/templatetags/version_spec.py
@@ -1,4 +1,5 @@
 from django import template
+from django.utils.translation import ugettext as _
 
 register = template.Library()
 
@@ -6,6 +7,6 @@ register = template.Library()
 @register.filter()
 def version_spec(value):
     if value == '*':
-        return ''
+        return _('all versions')
     else:
         return value

--- a/nextcloudappstore/core/templatetags/version_spec.py
+++ b/nextcloudappstore/core/templatetags/version_spec.py
@@ -1,5 +1,4 @@
 from django import template
-from django.utils.translation import ugettext as _
 
 register = template.Library()
 
@@ -7,6 +6,6 @@ register = template.Library()
 @register.filter()
 def version_spec(value):
     if value == '*':
-        return _('all versions')
+        return ''
     else:
         return value


### PR DESCRIPTION
- only display the required PHP table row if it's set.
- if required PHP version is * display as "all versions", otherwise the PHP had no value and that looked weird.

![auswahl_135](https://cloud.githubusercontent.com/assets/33533/16979327/b7672642-4e60-11e6-8627-f23e08d09882.png)