### PR TITLE
Migrate owncloud versions and add validation for more elements

### DIFF
--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -282,6 +282,16 @@ The following character maximum lengths are enforced:
 * All description Strings are database text fields and therefore not limited in size
 * All other Strings have a maximum of 256 characters
 
+The following elements are either deprecated or for internal use only and will fail the validation if present:
+
+* **standalone**
+* **default_enable**
+* **shipped**
+* **public**
+* **remote**
+* **requiremin**
+* **requiremax**
+
 
 .. _info-schema:
 

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -61,7 +61,9 @@ A minimum valid **info.xml** would look like this:
         <version>8.8.2</version>
         <licence>agpl</licence>
         <dependencies>
-            <owncloud min-version="9.0"/>
+            <!-- owncloud tag is required on Nextcloud 9, 10 and 11 -->
+            <owncloud min-version="9.1"/>
+            <nextcloud min-version="10"/>
         </dependencies>
     </info>
 
@@ -107,7 +109,9 @@ A full blown example would look like this (needs to be utf-8 encoded):
             <lib>curl</lib>
             <lib>SimpleXML</lib>
             <lib>iconv</lib>
+            <!-- owncloud tag is required on Nextcloud 9, 10 and 11 -->
             <owncloud min-version="9.0" max-version="9.1"/>
+            <nextcloud min-version="9" max-version="10"/>
         </dependencies>
         <background-jobs>
             <job>OCA\DAV\CardDAV\Sync\SyncJob</job>
@@ -236,18 +240,20 @@ dependencies/lib
     * can contain a **min-version** attribute (maximum 3 digits separated by dots)
     * can contain a **max-version** attribute (maximum 3 digits separated by dots)
 dependencies/nextcloud
-    * required
+    * required on Nextcloud 12 or higher
+    * if absent white-listed owncloud versions will be taken from the owncloud element (see below)
     * must contain a **min-version** attribute (maximum 3 digits separated by dots)
     * can contain a **max-version** attribute (maximum 3 digits separated by dots)
 dependencies/owncloud
     * optional
-    * used for app migration period
+    * used for app migration period (Nextcloud 9, 10 and 11)
     * must contain a **min-version** attribute (**9.0**, **9.1** or **9.2**)
     * can contain a **max-version** attribute (**9.0**, **9.1** or **9.2**)
     * will be ignored if a **nextcloud** tag exists
-    * 9.0 will be translated to Nextcloud 9
-    * 9.1 will be translated to Nextcloud 10
-    * 9.2 will be translated to Nextcloud 11
+    * 9.0 will be migrated to Nextcloud 9
+    * 9.1 will be migrated to Nextcloud 10
+    * 9.2 will be migrated to Nextcloud 11
+    * All other versions will be ignored
 background-jobs/job
     * optional
     * must contain a php class which is run as background jobs

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -250,31 +250,31 @@ dependencies/owncloud
     * 9.2 will be translated to Nextcloud 11
 background-jobs/job
     * optional
-    * must contain php classes that are run as background jobs
+    * must contain a php class which is run as background jobs
     * will not be used, only validated
 repair-steps/pre-migration/step
     * optional
-    * must contain php classes that are run before executing database migrations
+    * must contain a php class which is run before executing database migrations
     * will not be used, only validated
 repair-steps/post-migration/step
     * optional
-    * must contain php classes that are run after executing database migrations
+    * must contain a php class which is run after executing database migrations
     * will not be used, only validated
 repair-steps/live-migration/step
     * optional
-    * must contain php classes that are run after executing post-migration jobs
+    * must contain a php class which is run after executing post-migration jobs
     * will not be used, only validated
 repair-steps/install/step
     * optional
-    * must contain php classes that are run after installing the app
+    * must contain a php class which is run after installing the app
     * will not be used, only validated
 repair-steps/uninstall/step
     * optional
-    * must contain php classes that are run after uninstalling the app
+    * must contain a php class which is run after uninstalling the app
     * will not be used, only validated
 two-factor-providers/two-factor-provider
     * optional
-    * must contain php classes that are registered as two factor auth providers
+    * must contain a php class which is registered as two factor auth provider
     * will not be used, only validated
 
 The following character maximum lengths are enforced:

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -212,7 +212,7 @@ dependencies/lib
     * can occur multiple times with different php extensions
     * can contain a **min-version** attribute (maximum 3 digits separated by dots)
     * can contain a **max-version** attribute (maximum 3 digits separated by dots)
-dependencies/owncloud
+dependencies/nextcloud
     * required
     * must contain a **min-version** attribute (maximum 3 digits separated by dots)
     * can contain a **max-version** attribute (maximum 3 digits separated by dots)

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -109,6 +109,20 @@ A full blown example would look like this (needs to be utf-8 encoded):
             <lib>iconv</lib>
             <owncloud min-version="9.0" max-version="9.1"/>
         </dependencies>
+        <background-jobs>
+            <job>OCA\DAV\CardDAV\Sync\SyncJob</job>
+        </background-jobs>
+        <repair-steps>
+            <pre-migration>
+                <job>OCA\DAV\Migration\Classification</job>
+            </pre-migration>
+            <post-migration>
+                <job>OCA\DAV\Migration\Classification</job>
+            </post-migration>
+            <live-migration>
+                <job>OCA\DAV\Migration\GenerateBirthdays</job>
+            </live-migration>
+        </repair-steps>
     </info>
 
 The following tags are validated and used in the following way:
@@ -225,6 +239,22 @@ dependencies/owncloud
     * 9.0 will be translated to Nextcloud 9
     * 9.1 will be translated to Nextcloud 10
     * 9.2 will be translated to Nextcloud 11
+background-jobs
+    * optional
+    * must contain php classes that are run as background jobs
+    * will not be used, only validated
+repair-steps/pre-migration
+    * optional
+    * must contain php classes that are run before executing database migrations
+    * will not be used, only validated
+repair-steps/post-migration
+    * optional
+    * must contain php classes that are run after executing database migrations
+    * will not be used, only validated
+repair-steps/live-migration
+    * optional
+    * must contain php classes that are after executing post-migration jobs
+    * will not be used, only validated
 
 The following character maximum lengths are enforced:
 

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -114,15 +114,24 @@ A full blown example would look like this (needs to be utf-8 encoded):
         </background-jobs>
         <repair-steps>
             <pre-migration>
-                <job>OCA\DAV\Migration\Classification</job>
+                <step>OCA\DAV\Migration\Classification</step>
             </pre-migration>
             <post-migration>
-                <job>OCA\DAV\Migration\Classification</job>
+                <step>OCA\DAV\Migration\Classification</step>
             </post-migration>
             <live-migration>
-                <job>OCA\DAV\Migration\GenerateBirthdays</job>
+                <step>OCA\DAV\Migration\GenerateBirthdays</step>
             </live-migration>
+            <install>
+                <step>OCA\DAV\Migration\GenerateBirthdays</step>
+            </install>
+            <uninstall>
+                <step>OCA\DAV\Migration\GenerateBirthdays</step>
+            </uninstall>
         </repair-steps>
+        <two-factor-providers>
+            <two-factor-provider>OCA\AuthF\TwoFactor\Provider</two-factor-provider>
+        </two-factor-providers>
     </info>
 
 The following tags are validated and used in the following way:
@@ -239,21 +248,33 @@ dependencies/owncloud
     * 9.0 will be translated to Nextcloud 9
     * 9.1 will be translated to Nextcloud 10
     * 9.2 will be translated to Nextcloud 11
-background-jobs
+background-jobs/job
     * optional
     * must contain php classes that are run as background jobs
     * will not be used, only validated
-repair-steps/pre-migration
+repair-steps/pre-migration/step
     * optional
     * must contain php classes that are run before executing database migrations
     * will not be used, only validated
-repair-steps/post-migration
+repair-steps/post-migration/step
     * optional
     * must contain php classes that are run after executing database migrations
     * will not be used, only validated
-repair-steps/live-migration
+repair-steps/live-migration/step
     * optional
-    * must contain php classes that are after executing post-migration jobs
+    * must contain php classes that are run after executing post-migration jobs
+    * will not be used, only validated
+repair-steps/install/step
+    * optional
+    * must contain php classes that are run after installing the app
+    * will not be used, only validated
+repair-steps/uninstall/step
+    * optional
+    * must contain php classes that are run after uninstalling the app
+    * will not be used, only validated
+two-factor-providers/two-factor-provider
+    * optional
+    * must contain php classes that are registered as two factor auth providers
     * will not be used, only validated
 
 The following character maximum lengths are enforced:

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -272,7 +272,7 @@ repair-steps/uninstall/step
     * optional
     * must contain a php class which is run after uninstalling the app
     * will not be used, only validated
-two-factor-providers/two-factor-provider
+two-factor-providers/provider
     * optional
     * must contain a php class which is registered as two factor auth provider
     * will not be used, only validated

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -216,7 +216,15 @@ dependencies/nextcloud
     * required
     * must contain a **min-version** attribute (maximum 3 digits separated by dots)
     * can contain a **max-version** attribute (maximum 3 digits separated by dots)
-
+dependencies/owncloud
+    * optional
+    * used for app migration period
+    * must contain a **min-version** attribute (**9.0**, **9.1** or **9.2**)
+    * can contain a **max-version** attribute (**9.0**, **9.1** or **9.2**)
+    * will be ignored if a **nextcloud** tag exists
+    * 9.0 will be translated to Nextcloud 9
+    * 9.1 will be translated to Nextcloud 10
+    * 9.2 will be translated to Nextcloud 11
 
 The following character maximum lengths are enforced:
 

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -130,7 +130,7 @@ A full blown example would look like this (needs to be utf-8 encoded):
             </uninstall>
         </repair-steps>
         <two-factor-providers>
-            <two-factor-provider>OCA\AuthF\TwoFactor\Provider</two-factor-provider>
+            <provider>OCA\AuthF\TwoFactor\Provider</provider>
         </two-factor-providers>
     </info>
 

--- a/nextcloudappstore/core/api/v1/release/info.xsd
+++ b/nextcloudappstore/core/api/v1/release/info.xsd
@@ -418,7 +418,7 @@
 
     <xs:complexType name="two-factor-providers">
         <xs:sequence>
-            <xs:element name="two-factor-provider" type="php-class" minOccurs="1"
+            <xs:element name="provider" type="php-class" minOccurs="1"
                         maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>

--- a/nextcloudappstore/core/api/v1/release/info.xsd
+++ b/nextcloudappstore/core/api/v1/release/info.xsd
@@ -42,6 +42,8 @@
                             minOccurs="0" maxOccurs="1"/>
                 <xs:element name="repair-steps" type="repair-steps"
                             minOccurs="0" maxOccurs="1"/>
+                <xs:element name="two-factor-providers" type="two-factor-providers"
+                            minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
         </xs:complexType>
         <xs:unique name="uniqueNameL10n">
@@ -387,11 +389,15 @@
 
     <xs:complexType name="repair-steps">
         <xs:sequence>
-            <xs:element name="pre-migration" type="jobs" minOccurs="0"
+            <xs:element name="pre-migration" type="steps" minOccurs="0"
                         maxOccurs="1"/>
-            <xs:element name="post-migration" type="jobs" minOccurs="0"
+            <xs:element name="post-migration" type="steps" minOccurs="0"
                         maxOccurs="1"/>
-            <xs:element name="live-migration" type="jobs" minOccurs="0"
+            <xs:element name="live-migration" type="steps" minOccurs="0"
+                        maxOccurs="1"/>
+            <xs:element name="install" type="steps" minOccurs="0"
+                        maxOccurs="1"/>
+            <xs:element name="uninstall" type="steps" minOccurs="0"
                         maxOccurs="1"/>
         </xs:sequence>
     </xs:complexType>
@@ -399,6 +405,20 @@
     <xs:complexType name="jobs">
         <xs:sequence>
             <xs:element name="job" type="php-class" minOccurs="1"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="steps">
+        <xs:sequence>
+            <xs:element name="step" type="php-class" minOccurs="1"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="two-factor-providers">
+        <xs:sequence>
+            <xs:element name="two-factor-provider" type="php-class" minOccurs="1"
                         maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>

--- a/nextcloudappstore/core/api/v1/release/info.xsd
+++ b/nextcloudappstore/core/api/v1/release/info.xsd
@@ -38,6 +38,10 @@
                             maxOccurs="10"/>
                 <xs:element name="dependencies" type="dependencies"
                             minOccurs="1" maxOccurs="1"/>
+                <xs:element name="background-jobs" type="jobs"
+                            minOccurs="0" maxOccurs="1"/>
+                <xs:element name="repair-steps" type="repair-steps"
+                            minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
         </xs:complexType>
         <xs:unique name="uniqueNameL10n">
@@ -380,4 +384,29 @@
             <xs:enumeration value="64"/>
         </xs:restriction>
     </xs:simpleType>
+
+    <xs:complexType name="repair-steps">
+        <xs:sequence>
+            <xs:element name="pre-migration" type="jobs" minOccurs="0"
+                        maxOccurs="1"/>
+            <xs:element name="post-migration" type="jobs" minOccurs="0"
+                        maxOccurs="1"/>
+            <xs:element name="live-migration" type="jobs" minOccurs="0"
+                        maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="jobs">
+        <xs:sequence>
+            <xs:element name="job" type="php-class" minOccurs="1"
+                        maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:simpleType name="php-class">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[a-zA-Z_]+(\\[a-zA-Z_]+)*"/>
+        </xs:restriction>
+    </xs:simpleType>
+
 </xs:schema>

--- a/nextcloudappstore/core/api/v1/release/info.xsd
+++ b/nextcloudappstore/core/api/v1/release/info.xsd
@@ -425,7 +425,7 @@
 
     <xs:simpleType name="php-class">
         <xs:restriction base="xs:string">
-            <xs:pattern value="[a-zA-Z_]+(\\[a-zA-Z_]+)*"/>
+            <xs:pattern value="[a-zA-Z_][0-9a-zA-Z_]*(\\[a-zA-Z_][0-9a-zA-Z_]*)*"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/nextcloudappstore/core/api/v1/release/info.xsd
+++ b/nextcloudappstore/core/api/v1/release/info.xsd
@@ -329,12 +329,12 @@
                         maxOccurs="unbounded"/>
             <xs:element name="lib" type="min-max-version" minOccurs="0"
                         maxOccurs="unbounded"/>
-            <xs:element name="owncloud" type="owncloud" minOccurs="1"
+            <xs:element name="nextcloud" type="nextcloud" minOccurs="1"
                         maxOccurs="1"/>
         </xs:sequence>
     </xs:complexType>
 
-    <xs:complexType name="owncloud">
+    <xs:complexType name="nextcloud">
         <xs:attribute name="min-version" type="version" use="required"/>
         <xs:attribute name="max-version" type="version" use="optional"/>
     </xs:complexType>

--- a/nextcloudappstore/core/api/v1/release/info.xslt
+++ b/nextcloudappstore/core/api/v1/release/info.xslt
@@ -155,10 +155,10 @@
             </xsl:otherwise>
         </xsl:choose>
         <platform-min-version type="min-version">
-            <xsl:value-of select="owncloud/@min-version"/>
+            <xsl:value-of select="nextcloud/@min-version"/>
         </platform-min-version>
         <platform-max-version type="max-version">
-            <xsl:value-of select="owncloud/@max-version"/>
+            <xsl:value-of select="nextcloud/@max-version"/>
         </platform-max-version>
 
         <php-extensions type="list">

--- a/nextcloudappstore/core/api/v1/release/pre-info.xslt
+++ b/nextcloudappstore/core/api/v1/release/pre-info.xslt
@@ -33,6 +33,8 @@
             <xsl:copy-of select="discussion"/>
             <xsl:copy-of select="screenshot"/>
             <xsl:apply-templates select="dependencies"/>
+            <xsl:copy-of select="background-jobs"/>
+            <xsl:apply-templates select="repair-steps"/>
         </info>
     </xsl:template>
 
@@ -106,4 +108,13 @@
             </xsl:if>
         </dependencies>
     </xsl:template>
+
+    <xsl:template match="repair-steps">
+        <repair-steps>
+            <xsl:copy-of select="pre-migration"/>
+            <xsl:copy-of select="post-migration"/>
+            <xsl:copy-of select="live-migration"/>
+        </repair-steps>
+    </xsl:template>
+
 </xsl:stylesheet>

--- a/nextcloudappstore/core/api/v1/release/pre-info.xslt
+++ b/nextcloudappstore/core/api/v1/release/pre-info.xslt
@@ -75,12 +75,12 @@
                             </xsl:when>
                             <xsl:when test="$min = '9.1'">
                                 <xsl:attribute name="min-version">
-                                    <xsl:value-of select="10"/>
+                                    <xsl:value-of select="'10'"/>
                                 </xsl:attribute>
                             </xsl:when>
                             <xsl:when test="$min = '9.2'">
                                 <xsl:attribute name="min-version">
-                                    <xsl:value-of select="11"/>
+                                    <xsl:value-of select="'11'"/>
                                 </xsl:attribute>
                             </xsl:when>
                         </xsl:choose>
@@ -92,12 +92,12 @@
                             </xsl:when>
                             <xsl:when test="$max = '9.1'">
                                 <xsl:attribute name="max-version">
-                                    <xsl:value-of select="10"/>
+                                    <xsl:value-of select="'10'"/>
                                 </xsl:attribute>
                             </xsl:when>
                             <xsl:when test="$max = '9.2'">
                                 <xsl:attribute name="max-version">
-                                    <xsl:value-of select="11"/>
+                                    <xsl:value-of select="'11'"/>
                                 </xsl:attribute>
                             </xsl:when>
                         </xsl:choose>

--- a/nextcloudappstore/core/api/v1/release/pre-info.xslt
+++ b/nextcloudappstore/core/api/v1/release/pre-info.xslt
@@ -60,7 +60,50 @@
             <xsl:copy-of select="database"/>
             <xsl:copy-of select="command"/>
             <xsl:copy-of select="lib"/>
-            <xsl:copy-of select="owncloud"/>
+            <xsl:copy-of select="nextcloud"/>
+            <xsl:if test="not(nextcloud)">
+                <xsl:variable name="min" select="owncloud/@min-version[.='9.0' or '9.1' or '9.2']"/>
+                <xsl:variable name="max" select="owncloud/@max-version[.='9.0' or '9.1' or '9.2']"/>
+                <!-- if someone knows a better way to do this in xslt 1.0 feel free to patch it :) -->
+                <xsl:if test="$min or $max">
+                    <nextcloud>
+                        <xsl:choose>
+                            <xsl:when test="$min = '9.0'">
+                                <xsl:attribute name="min-version">
+                                    <xsl:value-of select="$min"/>
+                                </xsl:attribute>
+                            </xsl:when>
+                            <xsl:when test="$min = '9.1'">
+                                <xsl:attribute name="min-version">
+                                    <xsl:value-of select="10"/>
+                                </xsl:attribute>
+                            </xsl:when>
+                            <xsl:when test="$min = '9.2'">
+                                <xsl:attribute name="min-version">
+                                    <xsl:value-of select="11"/>
+                                </xsl:attribute>
+                            </xsl:when>
+                        </xsl:choose>
+                        <xsl:choose>
+                            <xsl:when test="$max = '9.0'">
+                                <xsl:attribute name="max-version">
+                                    <xsl:value-of select="$max"/>
+                                </xsl:attribute>
+                            </xsl:when>
+                            <xsl:when test="$max = '9.1'">
+                                <xsl:attribute name="max-version">
+                                    <xsl:value-of select="10"/>
+                                </xsl:attribute>
+                            </xsl:when>
+                            <xsl:when test="$max = '9.2'">
+                                <xsl:attribute name="max-version">
+                                    <xsl:value-of select="11"/>
+                                </xsl:attribute>
+                            </xsl:when>
+                        </xsl:choose>
+                    </nextcloud>
+                </xsl:if>
+            </xsl:if>
         </dependencies>
     </xsl:template>
 </xsl:stylesheet>

--- a/nextcloudappstore/core/api/v1/release/pre-info.xslt
+++ b/nextcloudappstore/core/api/v1/release/pre-info.xslt
@@ -70,7 +70,7 @@
                         <xsl:choose>
                             <xsl:when test="$min = '9.0'">
                                 <xsl:attribute name="min-version">
-                                    <xsl:value-of select="$min"/>
+                                    <xsl:value-of select="'9'"/>
                                 </xsl:attribute>
                             </xsl:when>
                             <xsl:when test="$min = '9.1'">
@@ -87,7 +87,7 @@
                         <xsl:choose>
                             <xsl:when test="$max = '9.0'">
                                 <xsl:attribute name="max-version">
-                                    <xsl:value-of select="$max"/>
+                                    <xsl:value-of select="'9'"/>
                                 </xsl:attribute>
                             </xsl:when>
                             <xsl:when test="$max = '9.1'">

--- a/nextcloudappstore/core/api/v1/release/pre-info.xslt
+++ b/nextcloudappstore/core/api/v1/release/pre-info.xslt
@@ -35,6 +35,11 @@
             <xsl:apply-templates select="dependencies"/>
             <xsl:copy-of select="background-jobs"/>
             <xsl:apply-templates select="repair-steps"/>
+
+            <!-- copy invalid elements to fail if they are present -->
+            <xsl:copy-of select="standalone"/>
+            <xsl:copy-of select="default_enable"/>
+            <xsl:copy-of select="shipped"/>
         </info>
     </xsl:template>
 

--- a/nextcloudappstore/core/api/v1/release/pre-info.xslt
+++ b/nextcloudappstore/core/api/v1/release/pre-info.xslt
@@ -35,11 +35,16 @@
             <xsl:apply-templates select="dependencies"/>
             <xsl:copy-of select="background-jobs"/>
             <xsl:apply-templates select="repair-steps"/>
+            <xsl:copy-of select="two-factor-providers"/>
 
             <!-- copy invalid elements to fail if they are present -->
             <xsl:copy-of select="standalone"/>
             <xsl:copy-of select="default_enable"/>
             <xsl:copy-of select="shipped"/>
+            <xsl:copy-of select="public"/>
+            <xsl:copy-of select="remote"/>
+            <xsl:copy-of select="requiremin"/>
+            <xsl:copy-of select="requiremax"/>
         </info>
     </xsl:template>
 
@@ -119,6 +124,8 @@
             <xsl:copy-of select="pre-migration"/>
             <xsl:copy-of select="post-migration"/>
             <xsl:copy-of select="live-migration"/>
+            <xsl:copy-of select="install"/>
+            <xsl:copy-of select="uninstall"/>
         </repair-steps>
     </xsl:template>
 

--- a/nextcloudappstore/core/api/v1/tests/data/infoxmls/invalid-elements.xml
+++ b/nextcloudappstore/core/api/v1/tests/data/infoxmls/invalid-elements.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../appmetadata/info.xsd">
+    <id>news</id>
+    <name>News</name>
+    <summary>An RSS/Atom feed reader</summary>
+    <description>An RSS/Atom feed reader</description>
+    <version>8.8.2</version>
+    <licence>agpl</licence>
+    <author>Bernhard Posselt</author>
+    <category>multimedia</category>
+    <dependencies>
+        <owncloud min-version="9.0"/>
+    </dependencies>
+    <standalone/>
+    <default_enable/>
+    <shipped>true</shipped>
+</info>

--- a/nextcloudappstore/core/api/v1/tests/data/infoxmls/nextcloud.xml
+++ b/nextcloudappstore/core/api/v1/tests/data/infoxmls/nextcloud.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../release/info.xsd">
+    <id>news</id>
+    <name>News</name>
+    <summary>An RSS/Atom feed reader</summary>
+    <description>An RSS/Atom feed reader</description>
+    <version>8.8.2</version>
+    <licence>agpl</licence>
+    <author>Bernhard Posselt</author>
+    <category>multimedia</category>
+    <dependencies>
+        <nextcloud min-version="10" max-version="11"/>
+        <owncloud min-version="9.0" max-version="9.1"/>
+    </dependencies>
+</info>

--- a/nextcloudappstore/core/api/v1/tests/data/infoxmls/repair-and-jobs.xml
+++ b/nextcloudappstore/core/api/v1/tests/data/infoxmls/repair-and-jobs.xml
@@ -23,6 +23,6 @@
         </post-migration>
     </repair-steps>
     <two-factor-providers>
-        <two-factor-provider>OCA\Hi</two-factor-provider>
+        <provider>OCA\Hi</provider>
     </two-factor-providers>
 </info>

--- a/nextcloudappstore/core/api/v1/tests/data/infoxmls/repair-and-jobs.xml
+++ b/nextcloudappstore/core/api/v1/tests/data/infoxmls/repair-and-jobs.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../appmetadata/info.xsd">
+    <id>news</id>
+    <name>News</name>
+    <summary>An RSS/Atom feed reader</summary>
+    <description>An RSS/Atom feed reader</description>
+    <version>8.8.2</version>
+    <licence>agpl</licence>
+    <author>Bernhard Posselt</author>
+    <category>multimedia</category>
+    <dependencies>
+        <owncloud min-version="9.0"/>
+    </dependencies>
+    <background-jobs>
+        <job>OCA\DAV\CardDAV\Sync\SyncJob</job>
+    </background-jobs>
+    <repair-steps>
+        <live-migration>
+            <job>OCA\DAV\Migration\GenerateBirthdays</job>
+        </live-migration>
+        <post-migration>
+            <job>OCA\DAV\Migration\Classification</job>
+        </post-migration>
+    </repair-steps>
+</info>

--- a/nextcloudappstore/core/api/v1/tests/data/infoxmls/repair-and-jobs.xml
+++ b/nextcloudappstore/core/api/v1/tests/data/infoxmls/repair-and-jobs.xml
@@ -16,10 +16,13 @@
     </background-jobs>
     <repair-steps>
         <live-migration>
-            <job>OCA\DAV\Migration\GenerateBirthdays</job>
+            <step>OCA\DAV\Migration\GenerateBirthdays</step>
         </live-migration>
         <post-migration>
-            <job>OCA\DAV\Migration\Classification</job>
+            <step>OCA\DAV\Migration\Classification</step>
         </post-migration>
     </repair-steps>
+    <two-factor-providers>
+        <two-factor-provider>OCA\Hi</two-factor-provider>
+    </two-factor-providers>
 </info>

--- a/nextcloudappstore/core/api/v1/tests/data/infoxmls/transform.xml
+++ b/nextcloudappstore/core/api/v1/tests/data/infoxmls/transform.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../release/info.xsd">
+    <id>news</id>
+    <name>News</name>
+    <summary>An RSS/Atom feed reader</summary>
+    <description>An RSS/Atom feed reader</description>
+    <version>8.8.2</version>
+    <licence>agpl</licence>
+    <author>Bernhard Posselt</author>
+    <category>multimedia</category>
+    <dependencies>
+        <owncloud min-version="9.1" max-version="9.2"/>
+    </dependencies>
+</info>

--- a/nextcloudappstore/core/api/v1/tests/test_parser.py
+++ b/nextcloudappstore/core/api/v1/tests/test_parser.py
@@ -52,6 +52,26 @@ class ParserTest(TestCase):
         }}
         self.assertDictEqual(expected, result)
 
+    def test_parse_minimal_transform(self):
+        xml = self._get_test_xml('data/infoxmls/transform.xml')
+        result = parse_app_metadata(xml, self.config.info_schema,
+                                    self.config.pre_info_xslt,
+                                    self.config.info_xslt)
+        min_version = result['app']['release']['platform_min_version']
+        max_version = result['app']['release']['platform_max_version']
+        self.assertEqual('10.0.0', min_version)
+        self.assertEqual('12.0.0', max_version)
+
+    def test_parse_minimal_nextcloud(self):
+        xml = self._get_test_xml('data/infoxmls/nextcloud.xml')
+        result = parse_app_metadata(xml, self.config.info_schema,
+                                    self.config.pre_info_xslt,
+                                    self.config.info_xslt)
+        min_version = result['app']['release']['platform_min_version']
+        max_version = result['app']['release']['platform_max_version']
+        self.assertEqual('10.0.0', min_version)
+        self.assertEqual('12.0.0', max_version)
+
     def test_validate_schema(self):
         xml = self._get_test_xml('data/infoxmls/invalid.xml')
         with (self.assertRaises(InvalidAppMetadataXmlException)):
@@ -246,7 +266,7 @@ class ParserTest(TestCase):
                 ],
                 'php_max_version': '*',
                 'php_min_version': '5.6.0',
-                'platform_max_version': '9.2.0',
+                'platform_max_version': '11.0.0',
                 'platform_min_version': '9.0.0',
                 'shell_commands': [
                     {'shell_command': {'name': 'grep'}},

--- a/nextcloudappstore/core/api/v1/tests/test_parser.py
+++ b/nextcloudappstore/core/api/v1/tests/test_parser.py
@@ -58,6 +58,13 @@ class ParserTest(TestCase):
                            self.config.pre_info_xslt,
                            self.config.info_xslt)
 
+    def test_parse_invalid_elements(self):
+        xml = self._get_test_xml('data/infoxmls/invalid-elements.xml')
+        with (self.assertRaises(InvalidAppMetadataXmlException)):
+            parse_app_metadata(xml, self.config.info_schema,
+                               self.config.pre_info_xslt,
+                               self.config.info_xslt)
+
     def test_parse_minimal_transform(self):
         xml = self._get_test_xml('data/infoxmls/transform.xml')
         result = parse_app_metadata(xml, self.config.info_schema,

--- a/nextcloudappstore/core/api/v1/tests/test_parser.py
+++ b/nextcloudappstore/core/api/v1/tests/test_parser.py
@@ -52,6 +52,12 @@ class ParserTest(TestCase):
         }}
         self.assertDictEqual(expected, result)
 
+    def test_parse_repair_jobs(self):
+        xml = self._get_test_xml('data/infoxmls/repair-and-jobs.xml')
+        parse_app_metadata(xml, self.config.info_schema,
+                           self.config.pre_info_xslt,
+                           self.config.info_xslt)
+
     def test_parse_minimal_transform(self):
         xml = self._get_test_xml('data/infoxmls/transform.xml')
         result = parse_app_metadata(xml, self.config.info_schema,


### PR DESCRIPTION
Works in the following way:
If no \<nextcloud> tag exists the versions will be taken from \<owncloud>  and following will be done:
* 9.0 will be transformed to 9.0
* 9.1 will be transformed to 10
* 9.2 will be transformed to 11

I hope that's enough and we dont need to consider further exceptions

Furthermore:
* validation and docs for background-jobs, repair-steps and two-factor-providers elements (please review @ChristophWurst , I assumed two-factor-providers/two-factor-provider as element that contains the class name)
* validation will fail if a non allowed element is found (shipped, default_enable, standalone) or if deprecated elements are used (requiremin, requiremax, public, remote)

@nickvergessen @janibonnevier @adsworth @LukasReschke @MorrisJobke please review