### PR TITLE
Fix #197: Consistent message placement

### DIFF
--- a/nextcloudappstore/core/templates/base.html
+++ b/nextcloudappstore/core/templates/base.html
@@ -24,15 +24,14 @@
 <div id="container">
     {% block navbar %}{% include 'nav.html' %}{% endblock %}
     <div class="container" id="body">
-        {% if messages %}
-            <div class="messages">
-                {% for message in messages %}
-                    <div {% if message.tags %} class="alert alert-{{ message.tags }}"{% endif %}>
-                        {{ message }}
-                    </div>
-                {% endfor %}
-            </div>
-        {% endif %}
+        <div class="messages">
+            {% for message in messages %}
+                <div {% if message.tags %} class="alert alert-{{ message.tags }}"{% endif %}>
+                    {{ message }}
+                </div>
+            {% endfor %}
+            {% block messages %}{% endblock %}
+        </div>
         {% block content %}{% endblock %}
     </div>
     <footer class="navbar-default" id="footer">

--- a/nextcloudappstore/core/templates/user/api-token.html
+++ b/nextcloudappstore/core/templates/user/api-token.html
@@ -9,12 +9,15 @@
 
 {% block head-title %}{% trans 'API Token' %} - {% endblock %}
 
+{% block messages %}
+    <div id="regen-success" class="alert alert-success" hidden>{% trans 'New API token generated.' %}</div>
+    <div id="regen-failure" class="alert alert-danger" hidden>{% trans 'Failed to regenerate API token.' %}</div>
+    <div id="token-failure" class="alert alert-danger" hidden>{% trans 'Failed to fetch token.' %}</div>
+{% endblock %}
+
 {% block account-content %}
     <h1>{% trans "API Token" %}</h1>
     <section id="tokenSection">
-        <div id="regen-success" class="alert alert-success" hidden>{% trans 'New API token generated.' %}</div>
-        <div id="regen-failure" class="alert alert-danger" hidden>{% trans 'Failed to regenerate API token.' %}</div>
-        <div id="token-failure" class="alert alert-danger" hidden>{% trans 'Failed to fetch token.' %}</div>
         <span id="regen-confirm-text" hidden>{% trans 'Do you want to regenerate your API token?' %}</span>
         <p>
             {% blocktrans %}


### PR DESCRIPTION
#197 

- Create template block for messages
- Fix message placement on token regen page

I did not touch the success message on the app upload page because I think it looks way better as it is. That page is very different from the rest anyway.