### PR TITLE
Adjust string lengths in schema

### DIFF
--- a/nextcloudappstore/core/api/v1/release/info.xsd
+++ b/nextcloudappstore/core/api/v1/release/info.xsd
@@ -97,7 +97,7 @@
     </xs:simpleType>
     <xs:simpleType name="limited-string">
         <xs:restriction base="non-empty-string">
-            <xs:maxLength value="128"/>
+            <xs:maxLength value="256"/>
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
Turns out string lengths were not adjusted in the schema when the models were changed. Every VARCHAR has a length of 256 chars now, this should now also be reflected in the schema.

@ChristophWurst @LukasReschke @janibonnevier 

That makes the mail app almost valid :D 