### PR TITLE
Fix screenshot height for images with small height

### DIFF
--- a/nextcloudappstore/core/static/assets/css/style.css
+++ b/nextcloudappstore/core/static/assets/css/style.css
@@ -230,11 +230,12 @@ form .text-danger {
 
 .app-list-container .app-list-screenshot {
     text-align: center;
+    height: 200px;
 }
 
 .app-list-container img {
     max-width: 100%;
-    height: 200px;
+    max-height: 100%;
 }
 
 .app-list-container .default-screenshot {


### PR DESCRIPTION
This fixes images that get stretched if their height is to small.

Before (see keeweb screenshot)
![2016-09-02-111229_841x348_scrot](https://cloud.githubusercontent.com/assets/3404133/18198934/7b27b3de-70fe-11e6-9579-dea794a84bbc.png)

After
![2016-09-02-111210_834x345_scrot](https://cloud.githubusercontent.com/assets/3404133/18198936/80073104-70fe-11e6-8371-f5de91956e38.png)

