### PR TITLE
Change rating urls

### DIFF
--- a/docs/restapi.rst
+++ b/docs/restapi.rst
@@ -536,7 +536,7 @@ Get All App Ratings
 ~~~~~~~~~~~~~~~~~~~
 This route will return all rating comments.
 
-* **Url**: GET /api/v1/apps/ratings.json
+* **Url**: GET /api/v1/ratings.json
 
 * **Authentication**: None
 
@@ -544,7 +544,7 @@ This route will return all rating comments.
 
 * **Example CURL request**::
 
-    curl https://apps.nextcloud.com/api/v1/apps/ratings.json -H 'If-None-Match: ""1-2016-09-03 17:11:38.772856+00:00""'
+    curl https://apps.nextcloud.com/api/v1/ratings.json -H 'If-None-Match: ""1-2016-09-03 17:11:38.772856+00:00""'
 
 * **Returns**: application/json
 

--- a/nextcloudappstore/core/api/v1/urls.py
+++ b/nextcloudappstore/core/api/v1/urls.py
@@ -13,7 +13,7 @@ urlpatterns = [
         name='app-release-create'),
     url(r'^apps/?$', AppRegisterView.as_view(), name='app-register'),
     url(r'^apps/(?P<pk>[a-z_]+)/?$', AppView.as_view(), name='app-delete'),
-    url(r'^apps/ratings.json$',
+    url(r'^ratings.json$',
         etag(app_ratings_etag)(AppRatingView.as_view()),
         name='app-ratings'),
     url(r'^apps/(?P<app>[a-z_]+)/releases/(?P<version>\d+\.\d+\.\d+'


### PR DESCRIPTION
First API break which is fine since nothing is stable yet :D

I've moved /apps/ratings.json to /ratings.json otherwise future API additions would make a route like /apps/news/something.json impossible

@janibonnevier @LukasReschke 