### PR TITLE
Fix #317 and #318: Rating form fixes

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -2,3 +2,4 @@
 <dev@bernhard-posselt.com> <bep@foryouandyourcustomers.com>
 Adi Sieker <adi@sieker.io> adsworth <adi@sieker.io>
 <lukas@statuscode.ch> <lukas@owncloud.com>
+<jani@bonnevier.one> <janibonnevier@users.noreply.github.com>

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -2,7 +2,7 @@ Authors
 =======
 
 * `Bernhard Posselt <mailto:dev@bernhard-posselt.com>`_
-* `Jani Bonnevier <mailto:janibonnevier@users.noreply.github.com>`_
+* `Jani Bonnevier <mailto:jani@bonnevier.one>`_
 * `Adi Sieker <mailto:adi@sieker.io>`_
 * `Lukas Reschke <mailto:lukas@statuscode.ch>`_
 * `Jannick Hemelhof <mailto:clone1612@me.com>`_
@@ -13,5 +13,6 @@ Authors
 * `Jannick Hemelhof <mailto:jhemelho@vub.ac.be>`_
 * `Jonne Haß <mailto:me@jhass.eu>`_
 * `Julius Härtl <mailto:github@jus.li>`_
+* `Maxence Lange <mailto:maxence@pontapreta.net>`_
 * `Susinthiran Nathan <mailto:fossxplorer@gmail.com>`_
 * `Thomas Wouters <mailto:twouters@users.noreply.github.com>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Changelog
 - Faster API and web interface due to reduced sql queries
 - Generate apps through the web interface
 - Combine app developer related tasks in one dropdown-menu
+- Hide app rating form from app owner
+- Naming and usability fixes for app rating form
 
 **Bugfixes**
 

--- a/nextcloudappstore/core/forms.py
+++ b/nextcloudappstore/core/forms.py
@@ -61,7 +61,7 @@ class AppRatingForm(Form):
     rating = ChoiceField(initial=0.5, choices=RATING_CHOICES,
                          widget=RadioSelect)
     comment = CharField(widget=Textarea, required=False,
-                        label=_('Review'))
+                        label=_('Comment'))
 
     class Meta:
         fields = ('rating', 'comment')

--- a/nextcloudappstore/core/templates/app/detail.html
+++ b/nextcloudappstore/core/templates/app/detail.html
@@ -120,7 +120,7 @@
                     <li><a rel="noreferrer noopener" href="{{ object.discussion }}" class="btn btn-secondary">{% trans 'Ask questions or discuss' %}</a></li>
                 {% endif %}
                 {% if request.user.is_authenticated and not user_has_rated_app and request.user != object.owner %}
-                    <li><button aria-expanded="true" data-toggle="collapse" data-target="#app-ratings" class="btn btn-secondary">{% trans 'Rate and review' %}</button></li>
+                    <li><button aria-expanded="true" data-toggle="collapse" data-target="#app-ratings" class="btn btn-secondary">{% trans 'Rate app' %}</button></li>
                 {% endif %}
             </ul>
         </div>
@@ -132,9 +132,9 @@
                     {% csrf_token %}
                     {% include 'form-fields.html' with form=rating_form %}
                     <p class="help-block">
-                        {% blocktrans %}Reviews support <a rel="noopener noreferrer" href="https://daringfireball.net/projects/markdown/syntax">Markdown</a>.
-                            Do not use reviews to report bugs or request features. Neither developers nor users will be notified by your review.
-                            A rating without a review still counts, but will not be listed below.{% endblocktrans %}
+                        {% blocktrans %}Rating comments support <a rel="noopener noreferrer" href="https://daringfireball.net/projects/markdown/syntax">Markdown</a>.
+                            Do not use rating comments to report bugs or request features. Neither developers nor users will be notified of your comment.
+                            A rating without a comment still counts, but will not be listed below.{% endblocktrans %}
                     </p>
                     {% if rating_form.is_bound %}
                         <input type="submit" value="{% trans 'Update rating' %}" class="btn btn-primary">

--- a/nextcloudappstore/core/templates/app/detail.html
+++ b/nextcloudappstore/core/templates/app/detail.html
@@ -119,13 +119,13 @@
                 {% if object.discussion %}
                     <li><a rel="noreferrer noopener" href="{{ object.discussion }}" class="btn btn-secondary">{% trans 'Ask questions or discuss' %}</a></li>
                 {% endif %}
-                {% if request.user.is_authenticated and not user_has_rated_app %}
-                    <li><button aria-expanded="true" data-toggle="collapse" data-target="#app-ratings" class="btn btn-secondary">{% trans 'Review app' %}</button></li>
+                {% if request.user.is_authenticated and not user_has_rated_app and request.user != object.owner %}
+                    <li><button aria-expanded="true" data-toggle="collapse" data-target="#app-ratings" class="btn btn-secondary">{% trans 'Rate and review' %}</button></li>
                 {% endif %}
             </ul>
         </div>
     {% endif %}
-    {% if request.user.is_authenticated %}
+    {% if request.user.is_authenticated and request.user != object.owner %}
         <div class="row app-ratings {% if not user_has_rated_app %}collapse{% endif %}" id="app-ratings">
             <div class="col-md-12">
                 <form action="{% url 'app-detail' object.id %}" method="post">
@@ -133,9 +133,14 @@
                     {% include 'form-fields.html' with form=rating_form %}
                     <p class="help-block">
                         {% blocktrans %}Reviews support <a rel="noopener noreferrer" href="https://daringfireball.net/projects/markdown/syntax">Markdown</a>.
-                            Do not use reviews to report bugs or request features. Neither developers nor users will be notified by your review.{% endblocktrans %}
+                            Do not use reviews to report bugs or request features. Neither developers nor users will be notified by your review.
+                            A rating without a review still counts, but will not be listed below.{% endblocktrans %}
                     </p>
-                    <input type="submit" value="{% trans 'Submit review' %}" class="btn btn-primary">
+                    {% if rating_form.is_bound %}
+                        <input type="submit" value="{% trans 'Update rating' %}" class="btn btn-primary">
+                    {% else %}
+                        <input type="submit" value="{% trans 'Submit rating' %}" class="btn btn-primary">
+                    {% endif %}
                 </form>
             </div>
         </div>

--- a/nextcloudappstore/core/views.py
+++ b/nextcloudappstore/core/views.py
@@ -80,7 +80,7 @@ class AppDetailView(DetailView):
                 except AppRating.DoesNotExist:
                     comment = ''
 
-                context['rating_form'] = AppRatingForm(initial={
+                context['rating_form'] = AppRatingForm({
                     'rating': app_rating.rating,
                     'comment': comment
                 })


### PR DESCRIPTION
Fix #317 and #318 

- Explain reviews
- Button says 'Update rating' if rating already exists.
- Hide rating form from app owner
- Update mailmap and authors