### PR TITLE
Allow changelog brackets

### DIFF
--- a/nextcloudappstore/core/api/v1/release/parser.py
+++ b/nextcloudappstore/core/api/v1/release/parser.py
@@ -310,7 +310,7 @@ def parse_changelog(changelog: str, version: str) -> str:
     if version.endswith('-nightly'):
         version = 'Unreleased'
     changelog = changelog.strip()
-    regex = re.compile(r'^## (\d+\.\d+\.\d+)')
+    regex = re.compile(r'^## (?:\[)?(\d+\.\d+\.\d+)')
     nightly_regex = re.compile(r'^## \[Unreleased\]')
     result = {}  # type: Dict[str, List[str]]
     curr_version = ''

--- a/nextcloudappstore/core/api/v1/tests/data/changelogs/0.6.0.md
+++ b/nextcloudappstore/core/api/v1/tests/data/changelogs/0.6.0.md
@@ -1,0 +1,33 @@
+### Added
+- Alias support
+  [#1523](https://github.com/owncloud/mail/pull/1523) @tahaalibra
+- New incoming messages are prefetched
+  [#1631](https://github.com/owncloud/mail/pull/1631) @ChristophWurst
+- Custom app folder support
+  [#1627](https://github.com/owncloud/mail/pull/1627) @juliushaertl
+- Improved search
+  [#1609](https://github.com/owncloud/mail/pull/1609) @ChristophWurst
+- Scroll to refresh
+  [#1595](https://github.com/owncloud/mail/pull/1593) @ChristophWurst
+- Shortcuts to star and mark messages as unread
+  [#1590](https://github.com/owncloud/mail/pull/1590) @ChristophWurst
+- Shortcuts to select previous/next messsage
+  [#1557](https://github.com/owncloud/mail/pull/1557) @ChristophWurst
+
+## Changed
+- Minimum server is Nextcloud 10/ownCloud 9.1
+  [#84](https://github.com/nextcloud/mail/pull/84) @ChristophWurst
+- Use session storage instead of local storage for client-side cache
+  [#1612](https://github.com/owncloud/mail/pull/1612) @ChristophWurst
+- When deleting the current message, the next one is selected immediatelly
+  [#1585](https://github.com/owncloud/mail/pull/1585) @ChristophWurst
+
+## Fixed
+- Client error while composing a new message
+  [#1609](https://github.com/owncloud/mail/pull/1609) @ChristophWurst
+- Delay app start until page has finished loading
+  [#1634](https://github.com/owncloud/mail/pull/1634) @ChristophWurst
+- Auto-redirection of HTML mail links
+  [#1603](https://github.com/owncloud/mail/pull/1603) @ChristophWurst
+- Update folder counters when reading/deleting messages
+  [#1585](https://github.com/owncloud/mail/pull/1585)

--- a/nextcloudappstore/core/api/v1/tests/data/changelogs/CHANGELOG.md
+++ b/nextcloudappstore/core/api/v1/tests/data/changelogs/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 - Sub-folders can not be selected
   [#1505](https://github.com/owncloud/mail/pull/1505) @ChristophWurst
 
-## 0.6.0 – 2016-09-20
+## [0.6.0] – 2016-09-20
 ### Added
 - Alias support
   [#1523](https://github.com/owncloud/mail/pull/1523) @tahaalibra

--- a/nextcloudappstore/core/api/v1/tests/test_parser.py
+++ b/nextcloudappstore/core/api/v1/tests/test_parser.py
@@ -471,6 +471,12 @@ class ParserTest(TestCase):
         expected = self._get_contents('data/changelogs/0.4.3.md').strip()
         self.assertEqual(expected, changelog)
 
+    def test_parse_changelog_brackets(self):
+        file = self._get_contents('data/changelogs/CHANGELOG.md')
+        changelog = parse_changelog(file, '0.6.0')
+        expected = self._get_contents('data/changelogs/0.6.0.md').strip()
+        self.assertEqual(expected, changelog)
+
     def test_parse_changelog_nightly(self):
         file = self._get_contents('data/changelogs/CHANGELOG.md')
         changelog = parse_changelog(file, '0.4.3-nightly')


### PR DESCRIPTION
This also parses versions in square brackets correctly like described on http://keepachangelog.com/en/0.3.0/

@ChristophWurst 