### PR TITLE
Remove Legacy Dependency-Tag information from Docs

### DIFF
--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -150,7 +150,7 @@ A minimum valid **info.xml** would look like this:
         <author>Bernhard Posselt</author>
         <category>multimedia</category>
         <dependencies>
-            <!-- owncloud tag is required on Nextcloud 9, 10 and 11 -->
+            <!-- owncloud tag is required on Nextcloud 9 and 10 -->
             <owncloud min-version="9.1"/>
             <nextcloud min-version="10"/>
         </dependencies>
@@ -197,7 +197,7 @@ A full blown example would look like this (needs to be utf-8 encoded):
             <lib>curl</lib>
             <lib>SimpleXML</lib>
             <lib>iconv</lib>
-            <!-- owncloud tag is required on Nextcloud 9, 10 and 11 -->
+            <!-- owncloud tag is required on Nextcloud 9 and 10 -->
             <owncloud min-version="9.0" max-version="9.1"/>
             <nextcloud min-version="9" max-version="10"/>
         </dependencies>
@@ -344,19 +344,17 @@ dependencies/lib
     * can contain a **min-version** attribute (maximum 3 digits separated by dots)
     * can contain a **max-version** attribute (maximum 3 digits separated by dots)
 dependencies/nextcloud
-    * required on Nextcloud 12 or higher
+    * required on Nextcloud 11 or higher
     * if absent white-listed owncloud versions will be taken from the owncloud element (see below)
     * must contain a **min-version** attribute (maximum 3 digits separated by dots)
     * can contain a **max-version** attribute (maximum 3 digits separated by dots)
 dependencies/owncloud
     * optional
-    * used for app migration period (Nextcloud 9, 10 and 11)
-    * must contain a **min-version** attribute (**9.0**, **9.1** or **9.2**)
-    * can contain a **max-version** attribute (**9.0**, **9.1** or **9.2**)
-    * will be ignored if a **nextcloud** tag exists
+    * used for app migration period (Nextcloud 9 and 10)
+    * must contain a **min-version** attribute (**9.0** or **9.1**)
+    * can contain a **max-version** attribute (**9.0** or **9.1**)
     * 9.0 will be migrated to Nextcloud 9
     * 9.1 will be migrated to Nextcloud 10
-    * 9.2 will be migrated to Nextcloud 11
     * All other versions will be ignored
 background-jobs/job
     * optional


### PR DESCRIPTION
According to https://github.com/nextcloud/server/pull/2139 😉 ...we'll not longer need to use 9.2 💪 
@BernhardPosselt ; discussed with @LukasReschke @nickvergessen 