### PR TITLE
RSS and Atom feed links now redirect to the app store app detail page…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Unreleased
 - Manage Nextcloud releases in the admin interface instead of a Python file
 - Apps need to provide a maximum version in addition to the minimum version
 - Apps do not need to provide an owncloud tag anymore for Nextcloud 11
+- RSS and Atom feed links now redirect to the app store app detail page instead of the download link. The download link is now available at the bottom of the entry
 
 **Removed**
 

--- a/nextcloudappstore/core/feeds.py
+++ b/nextcloudappstore/core/feeds.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.syndication.views import Feed
+from django.urls import reverse
 from django.urls import reverse_lazy
 from django.utils.feedgenerator import Atom1Feed
 from django.utils.translation import ugettext_lazy as _  # type: ignore
@@ -36,12 +37,13 @@ class AppReleaseRssFeed(Feed):
                 item.app.description, _('Changes'), item.changelog))
         except TranslationDoesNotExist:
             content = item.app.description
+        content += '\n\n [%s](%s)' % (_('Download'), item.download)
         return clean(markdown(content),
                      attributes=settings.MARKDOWN_ALLOWED_ATTRIBUTES,
                      tags=settings.MARKDOWN_ALLOWED_TAGS)
 
     def item_link(self, item):
-        return item.download
+        return reverse('app-detail', kwargs={'id': item.app.id})
 
     def item_author_name(self, item):
         return '%s %s' % (item.app.owner.first_name, item.app.owner.last_name)


### PR DESCRIPTION
… instead of the download link. The download link is now available at the bottom of the entry

@LukasReschke @adsworth @janibonnevier 