### PR TITLE
deduplicate app releases because the same version can match multiple …

### DIFF
--- a/nextcloudappstore/core/facades.py
+++ b/nextcloudappstore/core/facades.py
@@ -57,3 +57,18 @@ def any_match(predicate, iterable) -> bool:
         if predicate(entry):
             return True
     return False
+
+
+def distinct(iterable, criteria=id):
+    """
+    :param iterable:
+    :param criteria: by default the object in the list. Pass a lambda to choose
+    a custom distinctness criteria
+    :return: a distinct iterator of elements from an iterable
+    """
+    occurred_values = set()
+    for element in iterable:
+        value = criteria(element)
+        if value not in occurred_values:
+            occurred_values.add(value)
+            yield element

--- a/nextcloudappstore/core/tests/test_compatibility.py
+++ b/nextcloudappstore/core/tests/test_compatibility.py
@@ -17,6 +17,93 @@ class CompatibilityTest(TestCase):
         self.app1.name = 'News'
         self.app1.description = 'RSS feed reader'
         self.app1.save()
+
+    def tearDown(self):
+        if hasattr(self, 'app1'):
+            self.app1.delete()
+        if hasattr(self, 'app2'):
+            self.app2.delete()
+        self.user.delete()
+
+    def test_compatible_apps_deduplication(self):
+        AppRelease.objects.create(app=self.app1, version='1.0.0',
+                                  platform_version_spec='>=9.0.0,<10.0.0')
+        AppRelease.objects.create(app=self.app1, version='2.0.0',
+                                  platform_version_spec='>=10.0.0,<11.0.0')
+        AppRelease.objects.create(app=self.app1, version='3.0.0',
+                                  platform_version_spec='>=10.0.0,<11.0.0')
+        NextcloudRelease.objects.create(version='9.0.0')
+        NextcloudRelease.objects.create(version='9.0.1')
+        NextcloudRelease.objects.create(version='9.0.2')
+        NextcloudRelease.objects.create(version='10.0.0')
+        releases = self.app1.releases_by_platform_v()
+        self.assertEqual(1, len(releases['9']))
+        self.assertEqual(2, len(releases['10']))
+
+    def test_compatible_apps(self):
+        self._create_example_releases()
+        apps = App.objects.get_compatible('12.0.0')
+        apps2 = App.objects.get_compatible('11.0.0')
+        apps3 = App.objects.get_compatible('10.0.0')
+        apps4 = App.objects.get_compatible('9.0.0')
+        self.assertEqual(len(apps), 1)
+        self.assertEqual(apps[0].id, self.app1.id)
+        self.assertEqual(len(apps2), 2)
+        self.assertEqual(len(apps3), 2)
+        self.assertEqual(len(apps4), 2)
+
+    def test_compatible_releases(self):
+        self._create_example_releases()
+        app1rel = self.app1.compatible_releases('12.0.0')
+        app1rel2 = self.app1.compatible_releases('9.0.0')
+        app2rel = self.app2.compatible_releases('10.0.0')
+        app2rel2 = self.app2.compatible_releases('9.0.0')
+        self.assertEqual(len(app1rel), 2)
+        self.assertEqual(len(app1rel2), 1)
+        self.assertEqual(len(app2rel), 1)
+        self.assertEqual(len(app2rel2), 1)
+
+    def test_compatible_unstable_releases(self):
+        self._create_example_releases()
+        app1 = self.app1.compatible_unstable_releases('12.0')
+        app2 = self.app2.compatible_unstable_releases('12.0')
+        self.assertEqual(app1[0].version, '6.0.0')
+        self.assertEqual(app1[0].is_nightly, True)
+        self.assertEqual(app1[1].version, '6.0.0-alpha')
+        self.assertEqual(len(app1), 2)
+        self.assertEqual(app2, [])
+
+    def test_compatible_releases_by_platform_v(self):
+        self._create_example_releases()
+        self._create_nextcloud_versions()
+        app1 = self.app1.latest_releases_by_platform_v()
+        app2 = self.app2.latest_releases_by_platform_v()
+        self.assertEqual(app1['9']['stable'].version, '2.0.0')
+        self.assertEqual(app1['9']['unstable'], None)
+        self.assertEqual(app1['10']['stable'].version, '3.0.0')
+        self.assertEqual(app1['10']['unstable'], None)
+        self.assertEqual(app1['11']['stable'].version, '4.0.0')
+        self.assertEqual(app1['11']['unstable'], None)
+        self.assertEqual(app1['12']['stable'].version, '5.0.0')
+        self.assertEqual(app1['12']['unstable'].version, '6.0.0')
+        self.assertEqual(app1['12']['unstable'].is_nightly, True)
+        self.assertEqual(app2['9']['stable'].version, '1.0.0')
+        self.assertEqual(app2['10']['stable'].version, '2.0.0')
+        self.assertEqual(app2['11']['stable'].version, '4.0.0')
+        self.assertEqual(app2['12']['stable'], None)
+
+    def test_correct_comparison(self):
+        self._create_example_releases()
+        self._create_nextcloud_versions()
+        app1 = self.app1.latest_releases_by_platform_v()
+        self.assertEqual(app1['10']['stable'].version, '3.0.0')
+        self.assertEqual(app1['12']['unstable'].version, '6.0.0')
+
+    def _create_nextcloud_versions(self):
+        for version in self.platform_versions:
+            NextcloudRelease.objects.create(version=version)
+
+    def _create_example_releases(self):
         AppRelease.objects.create(app=self.app1, version='1.0.0',
                                   platform_version_spec='>=9.0.0,<10.0.0')
         AppRelease.objects.create(app=self.app1, version='2.0.0',
@@ -46,66 +133,3 @@ class CompatibilityTest(TestCase):
                                   platform_version_spec='>=11.0.0,<12.0.0')
         AppRelease.objects.create(app=self.app2, version='4.0.0',
                                   platform_version_spec='>=11.0.0,<12.0.0')
-
-    def tearDown(self):
-        self.app1.delete()
-        self.app2.delete()
-        self.user.delete()
-
-    def test_compatible_apps(self):
-        apps = App.objects.get_compatible('12.0.0')
-        apps2 = App.objects.get_compatible('11.0.0')
-        apps3 = App.objects.get_compatible('10.0.0')
-        apps4 = App.objects.get_compatible('9.0.0')
-        self.assertEqual(len(apps), 1)
-        self.assertEqual(apps[0].id, self.app1.id)
-        self.assertEqual(len(apps2), 2)
-        self.assertEqual(len(apps3), 2)
-        self.assertEqual(len(apps4), 2)
-
-    def test_compatible_releases(self):
-        app1rel = self.app1.compatible_releases('12.0.0')
-        app1rel2 = self.app1.compatible_releases('9.0.0')
-        app2rel = self.app2.compatible_releases('10.0.0')
-        app2rel2 = self.app2.compatible_releases('9.0.0')
-        self.assertEqual(len(app1rel), 2)
-        self.assertEqual(len(app1rel2), 1)
-        self.assertEqual(len(app2rel), 1)
-        self.assertEqual(len(app2rel2), 1)
-
-    def test_compatible_unstable_releases(self):
-        app1 = self.app1.compatible_unstable_releases('12.0')
-        app2 = self.app2.compatible_unstable_releases('12.0')
-        self.assertEqual(app1[0].version, '6.0.0')
-        self.assertEqual(app1[0].is_nightly, True)
-        self.assertEqual(app1[1].version, '6.0.0-alpha')
-        self.assertEqual(len(app1), 2)
-        self.assertEqual(app2, [])
-
-    def test_compatible_releases_by_platform_v(self):
-        self._create_nextcloud_versions()
-        app1 = self.app1.latest_releases_by_platform_v()
-        app2 = self.app2.latest_releases_by_platform_v()
-        self.assertEqual(app1['9']['stable'].version, '2.0.0')
-        self.assertEqual(app1['9']['unstable'], None)
-        self.assertEqual(app1['10']['stable'].version, '3.0.0')
-        self.assertEqual(app1['10']['unstable'], None)
-        self.assertEqual(app1['11']['stable'].version, '4.0.0')
-        self.assertEqual(app1['11']['unstable'], None)
-        self.assertEqual(app1['12']['stable'].version, '5.0.0')
-        self.assertEqual(app1['12']['unstable'].version, '6.0.0')
-        self.assertEqual(app1['12']['unstable'].is_nightly, True)
-        self.assertEqual(app2['9']['stable'].version, '1.0.0')
-        self.assertEqual(app2['10']['stable'].version, '2.0.0')
-        self.assertEqual(app2['11']['stable'].version, '4.0.0')
-        self.assertEqual(app2['12']['stable'], None)
-
-    def test_correct_comparison(self):
-        self._create_nextcloud_versions()
-        app1 = self.app1.latest_releases_by_platform_v()
-        self.assertEqual(app1['10']['stable'].version, '3.0.0')
-        self.assertEqual(app1['12']['unstable'].version, '6.0.0')
-
-    def _create_nextcloud_versions(self):
-        for version in self.platform_versions:
-            NextcloudRelease.objects.create(version=version)


### PR DESCRIPTION
…times for the same nextcloud major release

Fix #399 

@janis91 @janibonnevier @LukasReschke @adsworth 