### PR TITLE
Fix phpunit directory casing

### DIFF
--- a/nextcloudappstore/core/scaffolding/app-templates/11/app/phpunit.integration.xml
+++ b/nextcloudappstore/core/scaffolding/app-templates/11/app/phpunit.integration.xml
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/bootstrap.php" colors="true">
     <testsuites>
         <testsuite name="integration">
-            <directory>./tests/integration</directory>
+            <directory>./tests/Integration</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/nextcloudappstore/core/scaffolding/app-templates/11/app/phpunit.xml
+++ b/nextcloudappstore/core/scaffolding/app-templates/11/app/phpunit.xml
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/bootstrap.php" colors="true">
     <testsuites>
         <testsuite name="unit">
-            <directory>./tests/unit</directory>
+            <directory>./tests/Unit</directory>
         </testsuite>
     </testsuites>
 </phpunit>


### PR DESCRIPTION
I have updated the casings for both of the phpunit xml files in root to match the directories exactly.

This will fix unfound test issues on GNU/Linux machines.