### PR TITLE
move the psycopg2 requirement to production.txt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,4 +16,3 @@ pyOpenSSL==16.2.0
 pem==16.1.0
 Markdown==2.6.8
 bleach==1.5.0
-psycopg2==2.6.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,3 +1,4 @@
 gunicorn==19.6.0
 newrelic==2.78.0.57
+psycopg2==2.6.2
 


### PR DESCRIPTION
- move the requirement to production.txt. base.txt is also used in dev environments which don't always have PostgreSQL installed.