### PR TITLE
add collaboration type

### DIFF
--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -277,6 +277,11 @@ A full blown example would look like this (needs to be utf-8 encoded):
                 <type>link</type>
             </navigation>
         </navigations>
+        <collaboration>
+            <plugins>
+                <plugin type="collaborator-search" shareType="SHARE_TYPE_CIRCLE">OCA\Circles\Collaboration\v1\CollaboratorSearchPlugin</plugin>
+            </plugins>
+        </collaboration>
     </info>
 
 The following tags are validated and used in the following way:
@@ -482,7 +487,17 @@ navigations/navigation/type
     * can be either link or settings
     * link means that the entry is added to the default app menu
     * settings means that the entry is added to the right-side menu which also contains the personal, admin, users, help and logout entry
-
+collaboration
+    * optional
+    * can contain plugins for collaboration search (e.g. supplying share dialog)
+collaboration/plugins
+    * optional
+    * must contain at least one plugin
+collaboration/plugins/plugin
+    * required
+    * the PHP class name of the plugin
+    * must contain **type** attribute (currently only *collaboration-search*). The class must implement OCP\Collaboration\Collaborators\ISearchPlugin.
+    * must contain **shareType** attribute, according to the specific \OCP\Share constants
 
 The following character maximum lengths are enforced:
 

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -279,7 +279,7 @@ A full blown example would look like this (needs to be utf-8 encoded):
         </navigations>
         <collaboration>
             <plugins>
-                <plugin type="collaborator-search" shareType="SHARE_TYPE_CIRCLE">OCA\Circles\Collaboration\v1\CollaboratorSearchPlugin</plugin>
+                <plugin type="collaborator-search" share-type="SHARE_TYPE_CIRCLE">OCA\Circles\Collaboration\v1\CollaboratorSearchPlugin</plugin>
             </plugins>
         </collaboration>
     </info>
@@ -497,7 +497,7 @@ collaboration/plugins/plugin
     * required
     * the PHP class name of the plugin
     * must contain **type** attribute (currently only *collaboration-search*). The class must implement OCP\Collaboration\Collaborators\ISearchPlugin.
-    * must contain **shareType** attribute, according to the specific \OCP\Share constants
+    * must contain **share-type** attribute, according to the specific \OCP\Share constants
 
 The following character maximum lengths are enforced:
 

--- a/nextcloudappstore/api/v1/release/info.xsd
+++ b/nextcloudappstore/api/v1/release/info.xsd
@@ -452,7 +452,7 @@
         <xs:simpleContent>
             <xs:extension base="php-class">
                 <xs:attribute name="type" type="collaboration-plugin-type" use="required"/>
-                <xs:attribute name="shareType" type="shareType" use="required" />
+                <xs:attribute name="share-type" type="share-type" use="required" />
             </xs:extension>
         </xs:simpleContent>
     </xs:complexType>
@@ -463,7 +463,7 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <xs:simpleType name="shareType">
+    <xs:simpleType name="share-type">
         <xs:restriction base="xs:string">
             <xs:enumeration value="SHARE_TYPE_USER"/>
             <xs:enumeration value="SHARE_TYPE_GROUP"/>

--- a/nextcloudappstore/api/v1/release/info.xsd
+++ b/nextcloudappstore/api/v1/release/info.xsd
@@ -436,31 +436,45 @@
 
     <xs:complexType name="collaboration">
         <xs:sequence>
-            <xs:element name="collaborators" type="collaboration-collaborators" minOccurs="0" maxOccurs="1">
+            <xs:element name="plugins" type="collaboration-plugins" minOccurs="0" maxOccurs="1">
             </xs:element>
         </xs:sequence>
     </xs:complexType>
 
-    <xs:complexType name="collaboration-collaborators">
+    <xs:complexType name="collaboration-plugins">
         <xs:sequence>
-            <xs:element name="searchPlugins" type="collaboration-collaborators-searchPlugins" minOccurs="0" maxOccurs="1">
+            <xs:element name="plugin" type="collaboration-plugins-plugin" minOccurs="1" maxOccurs="unbounded">
             </xs:element>
         </xs:sequence>
     </xs:complexType>
 
-    <xs:complexType name="collaboration-collaborators-searchPlugins">
-        <xs:sequence>
-            <xs:element name="searchPlugin" type="collaboration-collaborators-searchPlugins-searchPlugin" minOccurs="1" maxOccurs="unbounded">
-            </xs:element>
-        </xs:sequence>
+    <xs:complexType name="collaboration-plugins-plugin">
+        <xs:simpleContent>
+            <xs:extension base="php-class">
+                <xs:attribute name="type" type="collaboration-plugin-type" use="required"/>
+                <xs:attribute name="shareType" type="shareType" use="required" />
+            </xs:extension>
+        </xs:simpleContent>
     </xs:complexType>
 
-    <xs:complexType name="collaboration-collaborators-searchPlugins-searchPlugin">
-        <xs:sequence>
-            <xs:element name="class" type="php-class" minOccurs="1" maxOccurs="1"/>
-            <xs:element name="shareType" type="non-empty-string" minOccurs="1" maxOccurs="1"/>
-        </xs:sequence>
-    </xs:complexType>
+    <xs:simpleType name="collaboration-plugin-type">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="collaborator-search"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="shareType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="SHARE_TYPE_USER"/>
+            <xs:enumeration value="SHARE_TYPE_GROUP"/>
+            <xs:enumeration value="SHARE_TYPE_LINK"/>
+            <xs:enumeration value="SHARE_TYPE_EMAIL"/>
+            <xs:enumeration value="SHARE_TYPE_CONTACT"/>
+            <xs:enumeration value="SHARE_TYPE_REMOTE"/>
+            <xs:enumeration value="SHARE_TYPE_CIRCLE"/>
+            <xs:enumeration value="SHARE_TYPE_GUEST"/>
+        </xs:restriction>
+    </xs:simpleType>
 
     <!-- dependencies -->
     <xs:complexType name="dependencies">

--- a/nextcloudappstore/api/v1/release/info.xsd
+++ b/nextcloudappstore/api/v1/release/info.xsd
@@ -55,6 +55,8 @@
                             maxOccurs="1"/>
                 <xs:element name="contactsmenu" type="contactsmenu" minOccurs="0"
                             maxOccurs="1"/>
+                <xs:element name="collaboration" type="collaboration" minOccurs="0"
+                            maxOccurs="1" />
             </xs:sequence>
         </xs:complexType>
         <xs:unique name="uniqueNameL10n">
@@ -429,6 +431,34 @@
         <xs:sequence>
             <xs:element name="provider" type="php-class" minOccurs="1"
                         maxOccurs="1"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="collaboration">
+        <xs:sequence>
+            <xs:element name="collaborators" type="collaboration-collaborators" minOccurs="0" maxOccurs="1">
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="collaboration-collaborators">
+        <xs:sequence>
+            <xs:element name="searchPlugins" type="collaboration-collaborators-searchPlugins" minOccurs="0" maxOccurs="1">
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="collaboration-collaborators-searchPlugins">
+        <xs:sequence>
+            <xs:element name="searchPlugin" type="collaboration-collaborators-searchPlugins-searchPlugin" minOccurs="1" maxOccurs="unbounded">
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="collaboration-collaborators-searchPlugins-searchPlugin">
+        <xs:sequence>
+            <xs:element name="class" type="php-class" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="shareType" type="non-empty-string" minOccurs="1" maxOccurs="1"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/nextcloudappstore/api/v1/release/pre-info.xslt
+++ b/nextcloudappstore/api/v1/release/pre-info.xslt
@@ -41,6 +41,7 @@
             <xsl:apply-templates select="activity"/>
             <xsl:apply-templates select="navigations"/>
             <xsl:copy-of select="contactsmenu"/>
+            <xsl:copy-of select="collaboration" />
 
             <!-- copy invalid elements to fail if they are present -->
             <xsl:copy-of select="standalone"/>

--- a/nextcloudappstore/api/v1/tests/data/infoxmls/collaboration.xml
+++ b/nextcloudappstore/api/v1/tests/data/infoxmls/collaboration.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0"?>
+<info xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	  xsi:noNamespaceSchemaLocation="../../../release/info.xsd">
+	<id>circles</id>
+	<name>Circles</name>
+	<summary>Bring cloud-users closer together.</summary>
+	<description><![CDATA[Circles allows your users to create their own groups of users/colleagues/friends.
+Those groups of users (or 'circles') can then be used by any other app for sharing purpose (files, social feed, status update, messaging, ...).
+		]]>
+	</description>
+	<version>0.12.5</version>
+	<licence>agpl</licence>
+	<author>Maxence Lange</author>
+	<documentation>
+		<admin>https://github.com/nextcloud/circles/wiki</admin>
+	</documentation>
+	<category>tools</category>
+	<category>social</category>
+	<website>https://github.com/nextcloud/circles</website>
+	<bugs>https://github.com/nextcloud/circles/issues</bugs>
+	<repository>https://github.com/nextcloud/circles.git</repository>
+	<screenshot>https://raw.githubusercontent.com/nextcloud/circles/master/screenshots/0.12.0.png
+	</screenshot>
+	<dependencies>
+		<nextcloud min-version="12" max-version="13"/>
+	</dependencies>
+
+	<repair-steps>
+		<post-migration>
+			<step>OCA\Circles\Migration\UpdateShareTimeToTimestamp</step>
+			<step>OCA\Circles\Migration\ImportOwncloudCustomGroups</step>
+			<step>OCA\Circles\Migration\GenerateUniqueIdOnCreatedCircle</step>
+			<step>OCA\Circles\Migration\UsingShortenUniqueIdInsteadOfCircleId</step>
+		</post-migration>
+	</repair-steps>
+
+	<commands>
+		<command>OCA\Circles\Command\Clean</command>
+	</commands>
+
+	<activity>
+		<settings>
+			<setting>OCA\Circles\Activity\SettingAsModerator</setting>
+			<setting>OCA\Circles\Activity\SettingAsMember</setting>
+		</settings>
+		<filters>
+			<filter>OCA\Circles\Activity\Filter</filter>
+		</filters>
+		<providers>
+			<provider>OCA\Circles\Activity\Provider</provider>
+		</providers>
+	</activity>
+
+	<collaboration>
+		<collaborators>
+			<searchPlugins>
+				<searchPlugin>
+					<class>OCA\Circles\Collaboration\v1\CollaboratorSearchPlugin</class>
+					<shareType>SHARE_TYPE_CIRCLE</shareType>
+				</searchPlugin>
+			</searchPlugins>
+		</collaborators>
+	</collaboration>
+</info>

--- a/nextcloudappstore/api/v1/tests/data/infoxmls/collaboration.xml
+++ b/nextcloudappstore/api/v1/tests/data/infoxmls/collaboration.xml
@@ -52,13 +52,8 @@ Those groups of users (or 'circles') can then be used by any other app for shari
 	</activity>
 
 	<collaboration>
-		<collaborators>
-			<searchPlugins>
-				<searchPlugin>
-					<class>OCA\Circles\Collaboration\v1\CollaboratorSearchPlugin</class>
-					<shareType>SHARE_TYPE_CIRCLE</shareType>
-				</searchPlugin>
-			</searchPlugins>
-		</collaborators>
+		<plugins>
+			<plugin type="collaborator-search" shareType="SHARE_TYPE_CIRCLE">OCA\Circles\Collaboration\v1\CollaboratorSearchPlugin</plugin>
+		</plugins>
 	</collaboration>
 </info>

--- a/nextcloudappstore/api/v1/tests/data/infoxmls/collaboration.xml
+++ b/nextcloudappstore/api/v1/tests/data/infoxmls/collaboration.xml
@@ -53,7 +53,7 @@ Those groups of users (or 'circles') can then be used by any other app for shari
 
 	<collaboration>
 		<plugins>
-			<plugin type="collaborator-search" shareType="SHARE_TYPE_CIRCLE">OCA\Circles\Collaboration\v1\CollaboratorSearchPlugin</plugin>
+			<plugin type="collaborator-search" share-type="SHARE_TYPE_CIRCLE">OCA\Circles\Collaboration\v1\CollaboratorSearchPlugin</plugin>
 		</plugins>
 	</collaboration>
 </info>

--- a/nextcloudappstore/api/v1/tests/test_parser.py
+++ b/nextcloudappstore/api/v1/tests/test_parser.py
@@ -75,6 +75,13 @@ class ParserTest(TestCase):
                            self.config.pre_info_xslt,
                            self.config.info_xslt)
 
+    def test_parse_collaboration(self):
+        xml = self._get_contents(
+            'data/infoxmls/collaboration.xml')
+        parse_app_metadata(xml, self.config.info_schema,
+                           self.config.pre_info_xslt,
+                           self.config.info_xslt)
+
     def test_parse_pre_release(self):
         xml = self._get_contents('data/infoxmls/prerelease.xml')
         result = parse_app_metadata(xml, self.config.info_schema,


### PR DESCRIPTION
Depends on https://github.com/nextcloud/server/pull/6328, used in https://github.com/nextcloud/circles/pull/126

It looks fairly broad and complex… because "collaboration" is a pretty wide term and I've no idea what else could come there in future (or not). 

``shareType`` (line 461) could be an enumeration as well, however it would mean naming constants here and have a coupling to code. Not sure this is necessary, but if worthwhile I can change this. Opinions welcome about it.