### PR TITLE
Add dashboard category

### DIFF
--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -355,6 +355,7 @@ category
     * must contain one of the following values:
 
        * **customization**
+       * **dashboard**
        * **files**
        * **games**
        * **search**

--- a/nextcloudappstore/api/v1/release/info.xsd
+++ b/nextcloudappstore/api/v1/release/info.xsd
@@ -341,6 +341,7 @@
 
     <xs:simpleType name="category">
         <xs:restriction base="xs:string">
+            <xs:enumeration value="dashboard"/>
             <xs:enumeration value="security"/>
             <xs:enumeration value="customization"/>
             <xs:enumeration value="files"/>

--- a/nextcloudappstore/core/fixtures/categories.json
+++ b/nextcloudappstore/core/fixtures/categories.json
@@ -130,6 +130,16 @@
         }
     },
     {
+        "model": "core.categorytranslation",
+        "pk": 15,
+        "fields": {
+            "language_code": "en",
+            "name": "Dashboard",
+            "description": "Apps including Nextcloud Dashboard widgets",
+            "master": "dashboard"
+        }
+    },
+    {
         "model": "core.category",
         "pk": "customization",
         "fields": {
@@ -231,6 +241,14 @@
         "fields": {
             "created": "2019-11-18T14:20:12Z",
             "last_modified": "2019-11-18T14:20:12Z"
+        }
+    },
+    {
+        "model": "core.category",
+        "pk": "dashboard",
+        "fields": {
+            "created": "2020-08-04T15:50:12Z",
+            "last_modified": "2020-08-04T15:50:12Z"
         }
     }
 ]

--- a/nextcloudappstore/core/templates/translation/db_translations.txt
+++ b/nextcloudappstore/core/templates/translation/db_translations.txt
@@ -1,5 +1,7 @@
 {% trans "Customization" %}
 {% trans "Themes, layout and UX change apps" %}
+{% trans "Dashboard" %}
+{% trans "Apps including Nextcloud Dashboard widgets" %}
 {% trans "Files" %}
 {% trans "File management and Files app extension apps" %}
 {% trans "Games" %}


### PR DESCRIPTION
For https://github.com/nextcloud/server/issues/20930

Once merged:

- [ ] Update resources/app-info.xsd in server as well
- [ ] Add app store category to supporting apps info.xml