### PR TITLE
bump newrelic to latest of 5.x series

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,3 +1,3 @@
 uWSGI==2.0.19.1
-newrelic==5.8.0.136
+newrelic==5.24.0.153
 psycopg2==2.8.6


### PR DESCRIPTION
- 6.x dropped 3.5, that'll be for us with going to Django 3

Signed-off-by: Arthur Schiwon <blizzz@arthur-schiwon.de>