### PR TITLE
Handle malformated tar files

### DIFF
--- a/nextcloudappstore/api/v1/release/parser.py
+++ b/nextcloudappstore/api/v1/release/parser.py
@@ -165,7 +165,15 @@ def test_blacklisted_members(tar, blacklist):
     :raises: BlacklistedMemberException
     :return:
     """
-    for name in (n for n in tar.getnames() if tar.getmember(n).isdir()):
+    names = []
+    for n in tar.getnames():
+        try:
+            if tar.getmember(n).isdir():
+                names.append(n)
+        except:
+            pass
+
+    for name in names:
         for error, regex in blacklist.items():
             regex = re.compile(regex)
             if regex.search(name):


### PR DESCRIPTION
When getting the list of names in the tar files, we should only get valid members of the tar file. This is not always the case since recent version of python and we need to handle the exception.