### PR TITLE
Fix login issues

### DIFF
--- a/nextcloudappstore/user/signals.py
+++ b/nextcloudappstore/user/signals.py
@@ -34,7 +34,11 @@ def password_changed_signal(sender, instance, **kwargs):
 
     try:
         user = get_user_model().objects.get(pk=instance.pk)
-        if user.password != instance.password:
+        if (user.password != instance.password
+                and instance._password is not None):
+            # make sure we only send an email when user changed their
+            # password and _password is set and not when password hash
+            # was changed due to a new default hashing algorithm
             update_token(user.username)
             send_mail(
                     mail_subect,


### PR DESCRIPTION
- Don't send email when only the hash of the password changed due to an
  upgrade of the hashing algorythm used
- Wrap deleting and recreating token in a transation to prevent data
  race

Signed-off-by: Carl Schwan <carl@carlschwan.eu>