### PR TITLE
Fix CSP when logging with github on chromium

### DIFF
--- a/nextcloudappstore/settings/base.py
+++ b/nextcloudappstore/settings/base.py
@@ -206,7 +206,7 @@ CSP_FONT_SRC = ('\'self\'',)
 CSP_SCRIPT_SRC = ('\'self\'',)
 CSP_CONNECT_SRC = ('\'self\'',)
 CSP_STYLE_SRC = ('\'self\'',)
-CSP_FORM_ACTION = ('\'self\'',)
+CSP_FORM_ACTION = ('\'self\'', 'https://github.com',)
 
 CSP_SIGNUP = {
     'SCRIPT_SRC': ['https://google.com/recaptcha/',


### PR DESCRIPTION
Chromium requires the redirected url to also be in the csp rules. This is an inconsistent behavior between firefox and chrome