### PR TITLE
feat(scaffold): Implement optional csv logs for app scaffold requests

### DIFF
--- a/nextcloudappstore/scaffolding/views.py
+++ b/nextcloudappstore/scaffolding/views.py
@@ -11,6 +11,7 @@ from nextcloudappstore.scaffolding.forms import AppScaffoldingForm, \
 from django.conf import settings
 
 import csv
+from datetime import datetime
 
 
 class AppScaffoldingView(FormView):
@@ -31,8 +32,9 @@ class AppScaffoldingView(FormView):
     def form_valid(self, form):
         if settings.APP_SCAFFOLDING_LOG:
             with open(settings.APP_SCAFFOLDING_LOG, 'a') as csvfile:
+                entries = form.cleaned_data.values()
                 logwriter = csv.writer(csvfile, delimiter='|')
-                logwriter.writerow(form.cleaned_data.values())
+                logwriter.writerow([datetime.now(), *entries])
         buffer = build_archive(form.cleaned_data)
         response = HttpResponse(content_type='application/tar+gzip')
         response['Content-Disposition'] = 'attachment; filename="app.tar.gz"'

--- a/nextcloudappstore/scaffolding/views.py
+++ b/nextcloudappstore/scaffolding/views.py
@@ -8,6 +8,10 @@ from nextcloudappstore.scaffolding.archive import build_archive
 from nextcloudappstore.scaffolding.forms import AppScaffoldingForm, \
     IntegrationScaffoldingForm
 
+from django.conf import settings
+
+import csv
+
 
 class AppScaffoldingView(FormView):
     template_name = 'app/scaffold.html'
@@ -25,6 +29,10 @@ class AppScaffoldingView(FormView):
         return init
 
     def form_valid(self, form):
+        if settings.APP_SCAFFOLDING_LOG:
+            with open(settings.APP_SCAFFOLDING_LOG, 'a') as csvfile:
+                logwriter = csv.writer(csvfile, delimiter='|')
+                logwriter.writerow(form.cleaned_data.values())
         buffer = build_archive(form.cleaned_data)
         response = HttpResponse(content_type='application/tar+gzip')
         response['Content-Disposition'] = 'attachment; filename="app.tar.gz"'

--- a/nextcloudappstore/settings/base.py
+++ b/nextcloudappstore/settings/base.py
@@ -304,6 +304,9 @@ DISCOURSE_PARENT_CATEGORY_ID = 26
 # templates; first key is the Nextcloud version for which the app is generated
 APP_SCAFFOLDING_PROFILES = {}
 
+# Path to log app scaffording requests to a csv format
+APP_SCAFFOLDING_LOG = None
+
 # GitHub api configuration
 GITHUB_API_BASE_URL = 'https://api.github.com'
 GITHUB_API_TOKEN = None


### PR DESCRIPTION
If a path is specified in the config like `APP_SCAFFOLDING_LOG = '/tmp/newapps.csv'` every request for an app scaffold can be written to a csv file

Example CSV:
```
MySmallNewApp|21|Julius Härtl|admin@admin.com|http://homepage.com|https://github.com|['dashboard', 'multimedia', 'search']|My short summary|A longer description
```

- [ ] Check ci failures (might be on master as well)
- [ ] Check back with @DaphneMuller if that is sufficient
- [ ] Add note to the frontend that we collect information here