### PR TITLE
fix(scaffold): Sort newest Nextcloud release first in the app generator

### DIFF
--- a/nextcloudappstore/scaffolding/forms.py
+++ b/nextcloudappstore/scaffolding/forms.py
@@ -24,7 +24,7 @@ def get_categories():
 
 def get_versions():
     tpls = listdir(resolve_file_relative_path(__file__, 'app-templates'))
-    return sorted(((v, v) for v in tpls))
+    return sorted(((v, v) for v in tpls), reverse=True)
 
 
 def validate_id(input: str) -> None:


### PR DESCRIPTION
Make sure that the default selected version is always the latest:

![Screenshot 2023-01-09 at 14 21 24](https://user-images.githubusercontent.com/3404133/211317684-f29308f7-90eb-4b29-8447-da7e2ee015c7.png)

before it always was the lowest number (21)