### PR TITLE
postgre10->14, +run tests on python3.11

### DIFF
--- a/.github/workflows/yarn.yml
+++ b/.github/workflows/yarn.yml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11']
         db-type: [postgres, sqlite]
 
     services:
       postgres:
-        image: postgres:10
+        image: postgres:14
         env:
           POSTGRES_USER: postgres
           POSTGRES_DB: nextcloudappstore


### PR DESCRIPTION
In Ubuntu 22.04 default Postgres is version 14, so we switch running tests on this version.
Also added running tests on Python 3.11