### PR TITLE
Fix the baseline file in the boilerplate to be valid XML

### DIFF
--- a/nextcloudappstore/scaffolding/app-templates/24/app/tests/psalm-baseline.xml
+++ b/nextcloudappstore/scaffolding/app-templates/24/app/tests/psalm-baseline.xml
@@ -1,2 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.x-dev@">
+</files>

--- a/nextcloudappstore/scaffolding/app-templates/25/app/tests/psalm-baseline.xml
+++ b/nextcloudappstore/scaffolding/app-templates/25/app/tests/psalm-baseline.xml
@@ -1,2 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.x-dev@">
+</files>
+

--- a/nextcloudappstore/scaffolding/app-templates/25/app/tests/psalm-baseline.xml
+++ b/nextcloudappstore/scaffolding/app-templates/25/app/tests/psalm-baseline.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.x-dev@">
 </files>
-


### PR DESCRIPTION
The current boilerplate code has an invalid XML file included that breaks the psalm tests (the baseline file cannot be read correctly and thus psalm refuses to work).

This is just a quick fix to have a working psalm configuration.