### PR TITLE
Added `Password reset` rate limit configuration [H1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [4.2.0]  - 2023-0x-xx
+
+### Fixed
+
+- Added `Password reset` rate limit configuration
+
 ## [4.1.0]  - 2023-05-18
 
 ### Added

--- a/nextcloudappstore/core/templates/429.html
+++ b/nextcloudappstore/core/templates/429.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block head-title %}{% trans 'Forbidden' %} - {% endblock %}
+
+{% block content %}
+
+    <h1>{% trans 'Forbidden' %}</h1>
+
+    <p>{% trans 'Too many tries. Try again in a few minutes.' %}</p>
+
+{% endblock %}
+

--- a/nextcloudappstore/core/tests/e2e/base.py
+++ b/nextcloudappstore/core/tests/e2e/base.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Optional
 from urllib.parse import urlparse
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
@@ -92,6 +92,11 @@ class BaseStoreTest(StaticLiveServerTestCase):
 
     def wait_for_url(self, url: str) -> Any:
         WebDriverWait(self.selenium, SELENIUM_WAIT_SEC).until(exp_cond.url_contains(url))
+
+    def wait_for_url_match(self, url: str, timeout: Optional[int] = None) -> Any:
+        if timeout is None:
+            timeout = SELENIUM_WAIT_SEC
+        WebDriverWait(self.selenium, timeout).until(exp_cond.url_matches(url))
 
     def assertOnPage(self, url_name: str, kwargs: Dict[str, str] = None) -> None:
         parsed = urlparse(self.selenium.current_url)

--- a/nextcloudappstore/core/tests/e2e/test_reset_password.py
+++ b/nextcloudappstore/core/tests/e2e/test_reset_password.py
@@ -1,0 +1,24 @@
+from time import sleep
+
+from django.test import tag
+
+from nextcloudappstore.core.tests.e2e.base import BaseStoreTest
+
+
+@tag("e2e")
+class ResetPasswordTest(BaseStoreTest):
+    def test_reset_pass(self):
+        self.go_to("account_reset_password")
+        email_input = self.by_id("id_email")
+        email_input.clear()
+        email_input.send_keys("admin@admin.com")
+        email_input.submit()
+        self.wait_for_url("/password/reset/done")
+
+        self.go_to("account_reset_password")
+        email_input = self.by_id("id_email")
+        email_input.clear()
+        email_input.send_keys("admin@admin.com")
+        email_input.submit()
+        sleep(8)
+        assert not self.selenium.current_url.find("/password/reset/done") != -1

--- a/nextcloudappstore/settings/base.py
+++ b/nextcloudappstore/settings/base.py
@@ -122,6 +122,8 @@ REST_FRAMEWORK = {
     },
 }
 
+ACCOUNT_RATE_LIMITS = {"reset_password": "1/m"}
+
 SITE_ID = 1
 
 # Allauth configuration


### PR DESCRIPTION
Link: https://hackerone.com/reports/2052795

Limited by default to one request per minute, but configurable by admins.