### PR TITLE
added "gpl3" license, allowed ExApp with no scopes

### DIFF
--- a/nextcloudappstore/api/v1/release/info.xsd
+++ b/nextcloudappstore/api/v1/release/info.xsd
@@ -371,6 +371,7 @@
             <xs:enumeration value="mit"/>
             <xs:enumeration value="mpl"/>
             <xs:enumeration value="apache"/>
+            <xs:enumeration value="gpl3"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -656,7 +657,7 @@
 
     <xs:complexType name="scopes_required">
         <xs:sequence>
-            <xs:element name="value" type="xs:string" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element name="value" type="xs:string" minOccurs="0" maxOccurs="unbounded"/>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
_ExApp without any API scopes defined is needed for [context_chat_backend](https://github.com/nextcloud-releases/context_chat_backend)_