### PR TITLE
Simultaneously pressing Appeal Bugfix

### DIFF
--- a/nextcloudappstore/core/models.py
+++ b/nextcloudappstore/core/models.py
@@ -297,16 +297,13 @@ class AppRating(TranslatableModel):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._original_appeal = self.appeal
 
     def __str__(self) -> str:
         return str(self.rating)
 
     def save(self, *args, **kwargs):
-        if self._original_appeal == self.appeal:
-            self.rated_at = timezone.now()  # Only update 'rated_at' if 'appeal' has not changed
-        else:
-            self._original_appeal = self.appeal
+        if not getattr(self, "_appeal_changed", None):  # Only update 'rated_at' if 'appeal' has not changed
+            self.rated_at = timezone.now()
         super().save(*args, **kwargs)
         # update rating on the app
         app = self.app

--- a/nextcloudappstore/core/views.py
+++ b/nextcloudappstore/core/views.py
@@ -74,10 +74,12 @@ class AppDetailView(DetailView):
                         app_rating.delete()
                     else:
                         app_rating.appeal = False
+                        app_rating._appeal_changed = True
                         app_rating.save()
                 elif "appeal" in post_data and "comment_id" in post_data and app_rating.app.owner == request.user:
                     # author of App marked comment
                     app_rating.appeal = bool(post_data["appeal"])
+                    app_rating._appeal_changed = True
                     app_rating.save()
         else:
             form = AppRatingForm(request.POST, id=id, user=request.user)


### PR DESCRIPTION
When the author of the application simultaneously clicks “Cancel appeal” with the Administrator, the comment time will be updated, which should not happen.

The comment change date now does not change when the “appeal” state changes in any way.

_Code is much cleaner than it was before for this situation._