### PR TITLE
upload coverage in separate step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,19 +68,34 @@ jobs:
       - name: Generate coverage report
         run: |
           xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x8" make test venv_bin=""
-          make coverage venv_bin=""
+          make coverage venv_bin="" -o coverage_${{ matrix.python-version }}_${{ matrix.db-type }}.xml
 
-      - name: HTML coverage to artifacts
-        uses: actions/upload-artifact@v3
+      - name: Upload Codecov to artifacts
+        uses: actions/upload-artifact@v4
         with:
-          name: coverage_${{ matrix.python-version }}
-          path: ./htmlcov
+          name: coverage_${{ matrix.python-version }}_${{ matrix.db-type }}.xml
+          path: coverage_${{ matrix.python-version }}_${{ matrix.db-type }}.xml
           if-no-files-found: error
+
+  upload-codecov:
+    needs: [ test ]
+    permissions:
+      contents: none
+    runs-on: ubuntu-22.04
+    name: Upload Coverage
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Coverage Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: coverage
+          pattern: coverage_*
+          merge-multiple: true
 
       - name: Upload report to Codecov
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.xml
+          directory: coverage
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,13 +68,12 @@ jobs:
       - name: Generate coverage report
         run: |
           xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x8" make test venv_bin=""
-          make coverage venv_bin="" -o coverage_${{ matrix.python-version }}_${{ matrix.db-type }}.xml
+          make coverage venv_bin=""
 
       - name: Upload Codecov to artifacts
         uses: actions/upload-artifact@v4
         with:
           name: coverage_${{ matrix.python-version }}_${{ matrix.db-type }}.xml
-          path: coverage_${{ matrix.python-version }}_${{ matrix.db-type }}.xml
           if-no-files-found: error
 
   upload-codecov:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,6 +74,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage_${{ matrix.python-version }}_${{ matrix.db-type }}.xml
+          path: coverage.xml
           if-no-files-found: error
 
   upload-codecov:

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ l10n:
 
 .PHONY: coverage
 coverage:
-	$(coverage) html && $(coverage) xml
+	$(coverage) xml
 
 .PHONY: test-user
 test-user:


### PR DESCRIPTION
Recently, coverage often uploads with an error and we have to restart all actions from scratch, which wastes a lot of CPU time.

Ref: https://github.com/codecov/codecov-action/issues/926