### PR TITLE
Broken templates after django-allauth update

### DIFF
--- a/nextcloudappstore/core/templates/account/password_reset_done.html
+++ b/nextcloudappstore/core/templates/account/password_reset_done.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% load allauth %}
+{% load account %}
+{% block head_title %}
+    {% trans "Password Reset" %}
+{% endblock head_title %}
+{% block content %}
+    {% element h1 %}
+        {% trans "Password Reset" %}
+    {% endelement %}
+    {% if user.is_authenticated %}
+        {% include "account/snippets/already_logged_in.html" %}
+    {% endif %}
+    <p>
+        {% blocktrans %}We have sent you an email. If you have not received it please check your spam folder. Otherwise contact us if you do not receive it in a few minutes.{% endblocktrans %}
+    </p>
+{% endblock content %}

--- a/nextcloudappstore/core/templates/account/verification_sent.html
+++ b/nextcloudappstore/core/templates/account/verification_sent.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% load i18n %}
+{% load allauth %}
+{% block head_title %}
+    {% trans "Verify Your Email Address" %}
+{% endblock head_title %}
+{% block content %}
+    {% element h1 %}
+        {% trans "Verify Your Email Address" %}
+    {% endelement %}
+    <p>
+        {% blocktrans %}We have sent an email to you for verification. Follow the link provided to finalize the signup process. If you do not see the verification email in your main inbox, check your spam folder. Please contact us if you do not receive the verification email within a few minutes.{% endblocktrans %}
+    </p>
+{% endblock content %}

--- a/nextcloudappstore/templates/socialaccount/authentication_error.html
+++ b/nextcloudappstore/templates/socialaccount/authentication_error.html
@@ -1,0 +1,12 @@
+{% extends "user/base.html" %}
+{% load i18n %}
+{% load allauth %}
+{% block head_title %}
+    {% trans "Third-Party Login Failure" %}
+{% endblock head_title %}
+{% block content %}
+    {% element h1 %}
+        {% trans "Third-Party Login Failure" %}
+    {% endelement %}
+    <p>{% trans "An error occurred while attempting to login via your third-party account." %}</p>
+{% endblock content %}

--- a/nextcloudappstore/templates/socialaccount/login.html
+++ b/nextcloudappstore/templates/socialaccount/login.html
@@ -1,25 +1,32 @@
-{% extends "socialaccount/login.html" %}
+{% extends "user/base.html" %}
 {% load i18n %}
-{% load static %}
+{% load allauth %}
 
+{% block head_title %}
+    {% trans "Sign In" %}
+{% endblock head_title %}
 {% block content %}
-<div class="central-form">
     {% if process == "connect" %}
-        <h4>{% blocktrans with provider.name as provider %}Connect {{ provider }}{% endblocktrans %}</h4>
-
-        <p>{% blocktrans with provider.name as provider %}You are about to connect a new third party account from {{ provider }}.{% endblocktrans %}</p>
+        {% element h1 %}
+            {% blocktrans with provider.name as provider %}Connect {{ provider }}{% endblocktrans %}
+        {% endelement %}
+        <p>
+            {% blocktrans with provider.name as provider %}You are about to connect a new third-party account from {{ provider }}.{% endblocktrans %}
+        </p>
     {% else %}
-        <h4>{% blocktrans with provider.name as provider %}Sign In Via {{ provider }}{% endblocktrans %}</h4>
-
-        <p>{% blocktrans with provider.name as provider %}You are about to sign in using a third party account from {{ provider }}.{% endblocktrans %}</p>
+        {% element h1 %}
+            {% blocktrans with provider.name as provider %}Sign In Via {{ provider }}{% endblocktrans %}
+        {% endelement %}
+        <p>
+            {% blocktrans with provider.name as provider %}You are about to sign in using a third-party account from {{ provider }}.{% endblocktrans %}
+        </p>
     {% endif %}
-
-    <form method="post">
-        {% csrf_token %}
-        <button class="btn btn-primary" type="submit">
-            <span class="icon material-symbols-outlined">login</span>
-            {% trans "Continue" %}
-        </button>
-    </form>
-</div>
+    {% element form method="post" no_visible_fields=True %}
+        {% slot actions %}
+            {% csrf_token %}
+            {% element button type="submit" %}
+                {% trans "Continue" %}
+            {% endelement %}
+        {% endslot %}
+    {% endelement %}
 {% endblock content %}


### PR DESCRIPTION
```
Backwards incompatible changes

Refactored the built-in templates, with the goal of being able to adjust the look and feel of the whole project by only overriding a few core templates. This approach allows you to achieve visual results fast, but is of course more limited compared to styling all templates yourself. If your project provided its own templates then this change will not affect anything, but if you rely on (some of) the built-in templates your project may be affected.
```

going through all the templates and pages and finding things that don't work as expected..

Ref: https://github.com/pennersr/django-allauth/blob/main/ChangeLog.rst#0580-2023-10-26