### PR TITLE
host documentation on the GitHub

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -1,0 +1,23 @@
+name: Docs check
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build_docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Docs dependencies
+        run: python3 -m pip install ".[docs]"
+
+      - name: Build and push Docs
+        run: |
+          make html SPHINXOPTS="-W"

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -16,7 +16,9 @@ jobs:
           python-version: '3.10'
 
       - name: Install Docs dependencies
-        run: python3 -m pip install ".[docs]"
+        run: |
+          pip install poetry==1.6.1
+          poetry install --with=docs
 
       - name: Build and push Docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Docs
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,9 @@ jobs:
           python-version: '3.10'
 
       - name: Install Docs dependencies
-        run: python3 -m pip install ".[docs]"
+        run: |
+          pip install poetry==1.6.1
+          poetry install --with=docs
 
       - name: Build and push Docs
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Docs
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  build_push_docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Docs dependencies
+        run: python3 -m pip install ".[docs]"
+
+      - name: Build and push Docs
+        run: |
+          export CHANGES_DATE=`date -d"@$(git log -1 --pretty=%ct)" --iso-8601=seconds`
+          make html
+          git config --global user.name nextcloud-bot
+          git config --global user.email "nextcloud-bot@users.noreply.github.com"
+          docroot=`mktemp -d`
+          rsync -av "docs/_build/html/" "${docroot}/"
+          pushd "${docroot}"
+          git init
+          git remote add deploy "https://token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git checkout -b gh-pages
+          touch .nojekyll
+          git add .
+          msg="Docs: commit ${GITHUB_SHA} made on ${CHANGES_DATE} from ${GITHUB_REF} by ${GITHUB_ACTOR}"
+          git commit -am "${msg}"
+          git push deploy gh-pages --force
+          popd
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN_DOCS }}

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ initdb:
 	$(manage) setdefaultadminpassword --settings nextcloudappstore.settings.development
 
 .PHONY: docs
-docs:
+.PHONY: html
+docs html:
 	$(MAKE) -C $(CURDIR)/docs/ clean html
 
 .PHONY: update-dev-deps

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/nextcloud/appstore.svg?branch=master)](https://travis-ci.org/nextcloud/appstore)
 [![codecov](https://codecov.io/gh/nextcloud/appstore/branch/master/graph/badge.svg?token=ABLI0g5G9q)](https://codecov.io/gh/nextcloud/appstore)
-[![Documentation Status](https://readthedocs.org/projects/nextcloudappstore/badge/?version=latest)](http://nextcloudappstore.readthedocs.io/en/latest/?badge=latest)
+[![Docs](https://github.com/nextcloud/appstore/actions/workflows/docs.yml/badge.svg)](https://nextcloud.github.io/appstore/)
 [![iRequirements Status](https://requires.io/github/nextcloud/appstore/requirements.svg?branch=master)](https://requires.io/github/nextcloud/appstore/requirements/?branch=master)
 [![Package.json Status](https://david-dm.org/nextcloud/appstore.svg)](https://david-dm.org/nextcloud/appstore)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/846/badge)](https://bestpractices.coreinfrastructure.org/projects/846)
@@ -13,7 +13,7 @@
 A new app store for Nextcloud apps built with Django. Up and running at [https://apps.nextcloud.com](https://apps.nextcloud.com). We **do not handle Nextcloud integration**. Nextcloud integration is handled in the [Nextcloud Server repository](https://github.com/nextcloud/server).
 
 ## Documentation
-Documentation including setup and API specification is [available on Read the Docs](https://nextcloudappstore.readthedocs.io/en/latest/)
+Documentation including setup and API specification is available [on the GitHub Pages](https://nextcloud.github.io/appstore/)
 
 ## Contributing
 If you want to help in developing the App Store, translating or filing bugs and feature requests, please consult the [contributing guidelines](https://github.com/nextcloud/appstore/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
It's time to restore the documentation. Github pages are an excellent choice to host documentation on them.