### PR TITLE
fix: tslint complaining in CI

### DIFF
--- a/nextcloudappstore/core/static/assets/app/api/Ratings.ts
+++ b/nextcloudappstore/core/static/assets/app/api/Ratings.ts
@@ -76,16 +76,16 @@ export function convertRating(rating: IApiRating, lang: string): IRating {
     }
     const translation = rating.translations[lang] || {comment: ''};
     return {
-        id: rating.id,
+        appeal: rating.appeal,
         comment: translation.comment,
         fullUserName: fullName.trim(),
+        id: rating.id,
         ratedAt: rating.ratedAt,
         rating: {
             name: createRatingName(rating.rating),
             value: rating.rating,
         },
         relativeRatedAt: rating.relativeRatedAt,
-        appeal: rating.appeal,
     };
 }
 
@@ -124,22 +124,22 @@ export function findUserComment(result: IRatings): Maybe<string> {
 
 export function appealRating(url: string, token: string, rating: IRating, appeal = true) {
     return pageRequest({
-        url,
         data: {
             appeal: +appeal,
             comment_id: rating.id,
         },
         method: HttpMethod.POST,
+        url,
     }, token);
 }
 
 export function deleteRating(url: string, token: string, rating: IRating, admin = false) {
     return pageRequest({
-        url,
         data: {
-            decision: +!admin,
             comment_id: rating.id,
+            decision: +!admin,
         },
         method: HttpMethod.POST,
+        url,
     }, token);
 }

--- a/nextcloudappstore/core/static/assets/app/api/RatingsSpec.ts
+++ b/nextcloudappstore/core/static/assets/app/api/RatingsSpec.ts
@@ -8,6 +8,7 @@ describe('Ratings and comments', () => {
             lastName: 'jones',
         };
         const data = [{
+            appeal: false,
             id: 66,
             ratedAt: '2017-03-22T16:54:37.168975Z',
             rating: 0.5,
@@ -18,8 +19,8 @@ describe('Ratings and comments', () => {
                 },
             },
             user,
-            appeal: false,
         }, {
+            appeal: true,
             id: 66,
             ratedAt: '2017-03-22T16:54:37.168975Z',
             rating: 0.5,
@@ -30,8 +31,8 @@ describe('Ratings and comments', () => {
                 },
             },
             user,
-            appeal: true,
         }, {
+            appeal: true,
             id: 66,
             ratedAt: '2017-03-22T16:54:37.168975Z',
             rating: 0.5,
@@ -42,15 +43,14 @@ describe('Ratings and comments', () => {
                 },
             },
             user,
-            appeal: true,
         }, {
+            appeal: false,
             id: 66,
             ratedAt: '2017-03-22T16:54:37.168975Z',
             rating: 0.5,
             relativeRatedAt: '',
             translations: {},
             user,
-            appeal: false,
         }];
         const result = filterEmptyComments(data, 'de');
         expect(result.length).toBe(1);
@@ -58,6 +58,7 @@ describe('Ratings and comments', () => {
 
     it('convert and parse ratings', () => {
         const data = {
+            appeal: false,
             id: 66,
             ratedAt: '2017-03-22T16:54:37.168975Z',
             rating: 0.5,
@@ -71,7 +72,6 @@ describe('Ratings and comments', () => {
                 firstName: ' Tom',
                 lastName: 'Jones',
             },
-            appeal: false,
         };
 
         const result = convertRating(data, 'de');
@@ -84,6 +84,7 @@ describe('Ratings and comments', () => {
 
     it('convert and parse ratings with empty user names', () => {
         const data = {
+            appeal: true,
             id: 66,
             ratedAt: '2017-03-22T16:54:32.168975Z',
             rating: 1.0,
@@ -97,7 +98,6 @@ describe('Ratings and comments', () => {
                 firstName: '',
                 lastName: ' ',
             },
-            appeal: true,
         };
 
         const result = convertRating(data, 'de');
@@ -109,6 +109,7 @@ describe('Ratings and comments', () => {
 
     it('convert and parse bad rating', () => {
         const data = {
+            appeal: false,
             id: 66,
             ratedAt: '2017-03-22T16:54:32.168975Z',
             rating: 0.0,
@@ -122,7 +123,6 @@ describe('Ratings and comments', () => {
                 firstName: '',
                 lastName: ' ',
             },
-            appeal: false,
         };
 
         const result = convertRating(data, 'de');

--- a/nextcloudappstore/core/static/assets/app/app/templates/Ratings.ts
+++ b/nextcloudappstore/core/static/assets/app/app/templates/Ratings.ts
@@ -18,14 +18,14 @@ export function renderRating(template: HTMLTemplateElement,
 }
 
 export function renderRatingActions(template: HTMLTemplateElement,
-                             rating: IRating, lang: string, fallbackLang: string): HTMLElement {
+                                    rating: IRating, lang: string, fallbackLang: string): HTMLElement {
     const root = render(template, {});
     if (!rating.appeal) {
         // Remove these buttons from template if comment has no appeal for spam
         const buttonsToRemove = [
             'button.comment-actions__delete',
             'button.comment-actions__appeal_cancel',
-            'button.comment-actions__appeal_cancel_admin'
+            'button.comment-actions__appeal_cancel_admin',
         ];
         buttonsToRemove.forEach((buttonSelector) => {
             try {

--- a/tslint.json
+++ b/tslint.json
@@ -8,6 +8,7 @@
         "max-line-length": [true, 120],
         "prefer-const": true,
         "no-console": ["log", {"allow": ["warn", "error"]}],
-        "no-shadowed-variable": false
+        "no-shadowed-variable": false,
+        "ordered-imports": false
     }
 }


### PR DESCRIPTION
5-6 days ago, tslint started complaining without reason. Trying to fix this.


```
ERROR: nextcloudappstore/core/static/assets/app/api/Ratings.ts:80:9 - The key 'comment' is not sorted alphabetically
ERROR: nextcloudappstore/core/static/assets/app/api/Ratings.ts:128:9 - The key 'data' is not sorted alphabetically
ERROR: nextcloudappstore/core/static/assets/app/api/Ratings.ts:139:9 - The key 'data' is not sorted alphabetically
ERROR: nextcloudappstore/core/static/assets/app/api/Ratings.ts:141:13 - The key 'comment_id' is not sorted alphabetically
ERROR: nextcloudappstore/core/static/assets/app/api/RatingsSpec.ts:21:13 - The key 'appeal' is not sorted alphabetically
ERROR: nextcloudappstore/core/static/assets/app/api/RatingsSpec.ts:33:13 - The key 'appeal' is not sorted alphabetically
ERROR: nextcloudappstore/core/static/assets/app/api/RatingsSpec.ts:45:13 - The key 'appeal' is not sorted alphabetically
ERROR: nextcloudappstore/core/static/assets/app/api/RatingsSpec.ts:53:13 - The key 'appeal' is not sorted alphabetically
ERROR: nextcloudappstore/core/static/assets/app/api/RatingsSpec.ts:74:13 - The key 'appeal' is not sorted alphabetically
ERROR: nextcloudappstore/core/static/assets/app/api/RatingsSpec.ts:100:13 - The key 'appeal' is not sorted alphabetically
ERROR: nextcloudappstore/core/static/assets/app/api/RatingsSpec.ts:125:13 - The key 'appeal' is not sorted alphabetically
ERROR: nextcloudappstore/core/static/assets/app/app/templates/Ratings.ts:4:1 - Import sources within a group must be alphabetized.
ERROR: nextcloudappstore/core/static/assets/app/app/templates/Ratings.ts:21:30 - parameters are not aligned
ERROR: nextcloudappstore/core/static/assets/app/app/templates/Ratings.ts:28:58 - Missing trailing comma
```