### PR TITLE
optimized viewing of the AppStore pages

### DIFF
--- a/nextcloudappstore/core/views.py
+++ b/nextcloudappstore/core/views.py
@@ -144,7 +144,8 @@ class AppDetailView(DetailView):
         context["categories"] = Category.objects.prefetch_related("translations").all()
         context["latest_releases_by_platform_v"] = self.object.latest_releases_by_platform_v()
         context["is_integration"] = self.object.is_integration
-        context["is_outdated"] = self.object.is_outdated()
+        context["is_outdated"] = False  # self.object.is_outdated()
+        # this is greatly impact performance, more then 30% load on evety page serving.
 
         return context
 


### PR DESCRIPTION
Measurements were made locally on a fairly large database with records.

1. It was found that one of the latest changes simply incredibly loads the AppStore just when you view pages:

```python3
   context["is_outdated"] = False  # self.object.is_outdated() 
```

**Only this change is already present in the production, I made it yesterday.**

**Impact of it ultra huge**, for one page view it increases open time of page from `2s` to `3s` locally in my setup.
In AppStore yesterday it was like more `5s` in difference with enabled and disabled.

@edward-ly  can you take a look to thing how we can cache this or reimplement?

---

2. The remaining optimizations were applied to the original AppStore code, which was always like this, but since there were fewer applications and their releases in it before, this problem did not arise.

I did not apply these changes on the server, I only tested them locally.

Although they are small, these lines that are changed here are called dozens of times, for each version for each application, so the impact of their changes is significant.

```python3
   from semantic_version import SimpleSpec, Version
```

Impact: 3%-8%

``Spec`` is deprecated in raising invisible warnings inside each call. Replaced with non-deprecated version.


```python3
    filter(lambda r: (not r.is_unstable) and r.is_compatible(platform_version, inclusive), self.releases.all())
```

Impact: 5%-10%

Explanation: first faster to check for `bool` value, and after that starting parsing with custom functions.

```python3
   filter(lambda r: r.is_unstable and r.is_compatible(platform_version, inclusive), self.releases.all())
```

Impact: 5%-10%

Explanation: first faster to check for `bool` value, and after that starting parsing with custom functions.


```python3
    return min_version in spec or Version(pad_max_inc_version(platform_version)) in spec
```

Impact: 3%-5%

Explanation: Here we do not need to init with padding version and it should be in the right side to be per foment only if first condition does not triggered.


Overall, a rollback of the change introduced by Edward to determine whether a release is outdated or not + these 4 small changes in parsing each release - I hope will help reduce the load on the AppStore.