### PR TITLE
added cache for `60 sec` for `latest_releases_by_platform_v` method

### DIFF
--- a/nextcloudappstore/core/views.py
+++ b/nextcloudappstore/core/views.py
@@ -144,8 +144,7 @@ class AppDetailView(DetailView):
         context["categories"] = Category.objects.prefetch_related("translations").all()
         context["latest_releases_by_platform_v"] = self.object.latest_releases_by_platform_v()
         context["is_integration"] = self.object.is_integration
-        context["is_outdated"] = False  # self.object.is_outdated()
-        # this is greatly impact performance, more then 30% load on evety page serving.
+        context["is_outdated"] = self.object.is_outdated()
 
         return context
 


### PR DESCRIPTION
This will greatly speedup 

curl -o /dev/null -s -w "Total time: %{time_total}\n" 'https://apps.nextcloud.com/apps/mail'
curl -o /dev/null -s -w "Total time: %{time_total}\n" 'https://apps.nextcloud.com/apps/spreed'


Do not know for how for how much time we can cache it, maybe increasing value to 3(or 5?) mins will be an option.


```shell
curl -o /dev/null -s -w "Total time: %{time_total}\n" 'https://apps.nextcloud.com/apps/mail'
Total time: 7.594651
curl -o /dev/null -s -w "Total time: %{time_total}\n" 'https://apps.nextcloud.com/apps/mail'
Total time: 0.927678
curl -o /dev/null -s -w "Total time: %{time_total}\n" 'https://apps.nextcloud.com/apps/mail'
Total time: 0.910507
```
