### PR TITLE
consider "integrations" always up to date

### DIFF
--- a/nextcloudappstore/core/models.py
+++ b/nextcloudappstore/core/models.py
@@ -319,6 +319,8 @@ class App(TranslatableModel):
         :return: True if not compatible, otherwise false
         """
 
+        if self.is_integration:
+            return False
         release_versions = list(self.latest_releases_by_platform_v().keys())
         if not release_versions:
             return True


### PR DESCRIPTION
Integrations does not have releases and was always marked as "outdated".

Reported by Simon, he spotted it on the AIO integration marked as outdated.

This fixes this(already deployed for test)