### PR TITLE
Rate Limiting for "Account Already Exists" Email in Signup Process

### DIFF
--- a/nextcloudappstore/urls.py
+++ b/nextcloudappstore/urls.py
@@ -17,6 +17,7 @@ from nextcloudappstore.core.views import (
     AppReleasesView,
     AppUploadView,
     CategoryAppListView,
+    CustomSignupView,
     app_description,
 )
 from nextcloudappstore.scaffolding.views import (
@@ -46,6 +47,7 @@ urlpatterns = [
     re_path(r"^admin/", admin.site.urls),
     path("i18n/", include("django.conf.urls.i18n")),
     path("captcha/", include("captcha.urls")),
+    path("accounts/signup/", CustomSignupView.as_view(), name="account_signup"),
 ]
 
 urlpatterns += i18n_patterns(


### PR DESCRIPTION
**Description:**

We added a custom signup view `CustomSignupView` to override the default `SignupView`. This view checks if the email entered during signup already exists in our database. If it does, it uses Redis to determine if the "Account Already Exists" email has been sent to that email address within the last 24 hours.

- **How it works:**
  - **`form_valid` Method:** When the signup form is valid, it retrieves the email and checks if it exists using the `email_exists` method.
    - If the email exists and the "Account Already Exists" email hasn't been sent in the last 24 hours (`should_send_account_exists_email` returns `False`), it skips sending the email and redirects the user to the login page with an informational message.
    - Otherwise, it proceeds with the default signup behavior.
  - **`email_exists` Method:** Checks the database for the existence of the email, ignoring case sensitivity.
  - **`should_send_account_exists_email` Method:** Uses Redis to store a key for each email address with a 24-hour expiration.
    - If the key exists, it returns `False`, indicating the email was recently sent.
    - If the key doesn't exist or Redis is unavailable, it returns `True`, allowing the email to be sent.

**Why:**

This change limits the "Account Already Exists" email to be sent at most once per day per email address. It reduces the number of emails sent from our application when users repeatedly attempt to register with an existing email. This helps prevent our emails from being marked as spam by our email provider and improves the user experience by avoiding redundant emails.