### PR TITLE
allow "scopes" be not present in "external-app"

### DIFF
--- a/nextcloudappstore/api/v1/release/info.xsd
+++ b/nextcloudappstore/api/v1/release/info.xsd
@@ -685,7 +685,7 @@
     <xs:complexType name="external-app">
         <xs:sequence>
             <xs:element name="docker-install" type="docker-install" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="scopes" type="scopes" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="scopes" type="scopes" minOccurs="0" maxOccurs="1"/>
             <xs:element name="system" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
     </xs:complexType>

--- a/nextcloudappstore/api/v1/tests/data/infoxmls/app_api_minimal.xml
+++ b/nextcloudappstore/api/v1/tests/data/infoxmls/app_api_minimal.xml
@@ -17,7 +17,5 @@
 			<image>cloud-py-api/skeleton</image>
 			<image-tag>latest</image-tag>
 		</docker-install>
-        <scopes>
-		</scopes>
     </external-app>
 </info>


### PR DESCRIPTION
we decided to abandon AppAPI scopes in AppAPI and the last three versions of AppAPI have already been released where it completely ignores them.

it's time to add the ability to not specify them in `info.xml` at all, since they are no longer needed.

we are not cutting them out of the AppStore completely yet, we need to wait at least six months so that those who have the old version of AppAPI now do not get crashes (old versions of AppAPI need this data and they expect that they will be)