### PR TITLE
fix(version): Fix unstable version handling

### DIFF
--- a/nextcloudappstore/core/models.py
+++ b/nextcloudappstore/core/models.py
@@ -509,7 +509,6 @@ class AppRelease(TranslatableModel):
         if self.is_nightly:
             return True
 
-        version = Version(self.version)
         return bool(Version(self.version).prerelease)
 
 

--- a/nextcloudappstore/core/models.py
+++ b/nextcloudappstore/core/models.py
@@ -506,16 +506,11 @@ class AppRelease(TranslatableModel):
 
     @property
     def is_unstable(self):
-        return (
-            self.is_nightly
-            or "-dev" in self.version
-            or "-a" in self.version
-            or "-alpha" in self.version
-            or "-b" in self.version
-            or "-beta" in self.version
-            or "-rc" in self.version
-            or "-RC" in self.version
-        )
+        if self.is_nightly:
+            return True
+
+        version = Version(self.version)
+        return bool(Version(self.version).prerelease)
 
 
 class AppApiReleaseDeployMethod(Model):


### PR DESCRIPTION
Basically I was wrong in https://github.com/nextcloud/appstore/pull/938
And `1.25.2-1` is actually an unstable version by SemVer definition.
But reverting back to before https://github.com/nextcloud/appstore/pull/938 is also incorrect, because `1.25.2+build-1` is actually not an unstable version.
Test regex available at https://regex101.com/r/Ly7O1x

I wonder if:
- https://github.com/nextcloud/appstore/blob/cce6ce5577aacfe7f293af59e073b467f05cd2db/nextcloudappstore/api/v1/release/parser.py#L307
- https://github.com/nextcloud/appstore/blob/483b51e254d8262264d937a36e0270628ac76222/nextcloudappstore/api/v1/release/importer.py#L362

Needs adjusting too.

The other question is if we should allow `+` in the app version field so that apps can actually use the buildversion from SemVer