### PR TITLE
(fix): broken user registration after Odoo enabled

### DIFF
--- a/nextcloudappstore/user/forms.py
+++ b/nextcloudappstore/user/forms.py
@@ -21,7 +21,7 @@ class SignupFormRecaptcha(forms.Form):
     first_name = CharField(max_length=30, label=_("First name"))
     last_name = CharField(max_length=30, label=_("Last name"))
     subscribe_to_news = forms.BooleanField(
-        label=_("I would like to receive app developer news and updates from Nextcloud by email (optional)"),
+        label=_("I would like to receive app developer news and updates from Nextcloud by email"),
         required=False,
         initial=False,
     )
@@ -36,7 +36,7 @@ class SignupFormRecaptcha(forms.Form):
         user.profile.save()
 
         if self.cleaned_data["subscribe_to_news"]:
-            subscribe_user_to_news(user)
+            subscribe_user_to_news(user.email, "")
 
 
 class DeleteAccountForm(forms.Form):
@@ -80,7 +80,7 @@ class AccountForm(forms.ModelForm):
         ),
     )
     subscribe_to_news = forms.BooleanField(
-        label=_("I would like to receive app developer news and updates from Nextcloud by email (optional)"),
+        label=_("I would like to receive app developer news and updates from Nextcloud by email"),
         required=False,
     )
 

--- a/nextcloudappstore/user/models.py
+++ b/nextcloudappstore/user/models.py
@@ -39,7 +39,7 @@ def handle_subscription_change(sender, instance, **kwargs):
         if old_value != new_value:
             if new_value:
                 # Logic to subscribe the user
-                subscribe_user_to_news(instance.user)
+                subscribe_user_to_news(instance.user.email, "")
             else:
                 # Logic to unsubscribe the user
-                unsubscribe_user_from_news(instance.user)
+                unsubscribe_user_from_news(instance.user.email)

--- a/nextcloudappstore/user/odoo.py
+++ b/nextcloudappstore/user/odoo.py
@@ -26,7 +26,7 @@ def is_odoo_config_valid():
     return all(required_fields)
 
 
-def subscribe_user_to_news(user):
+def subscribe_user_to_news(user_email: str, user_name: str):
     if not is_odoo_config_valid():
         print("Odoo configuration is invalid. Skipping subscription.")
         return
@@ -41,14 +41,14 @@ def subscribe_user_to_news(user):
         settings.ODOO_PASSWORD,
         "mailing.contact",
         "search",
-        [[("email", "=", user["email"])]],
+        [[("email", "=", user_email)]],
     )
 
     if not contact_ids:
         # Create a new contact if it doesn't exist
         contact_data = {
-            "name": user.get("name", user["email"]),  # Use name if provided, fallback to email
-            "email": user["email"],
+            "name": user_name if user_name else user_email,  # Use name if provided, fallback to email
+            "email": user_email,
         }
         contact_id = models.execute_kw(
             settings.ODOO_DB,
@@ -107,7 +107,7 @@ def subscribe_user_to_news(user):
         print(f"User's subscription updated to opt-in for mailing list {settings.ODOO_MAILING_LIST_ID}")
 
 
-def unsubscribe_user_from_news(user):
+def unsubscribe_user_from_news(user_email: str):
     if not is_odoo_config_valid():
         print("Odoo configuration is invalid. Skipping subscription.")
         return
@@ -121,11 +121,11 @@ def unsubscribe_user_from_news(user):
         settings.ODOO_PASSWORD,
         "mailing.contact",
         "search",
-        [[("email", "=", user["email"])]],
+        [[("email", "=", user_email)]],
     )
 
     if not contact_ids:
-        print(f"No contact found for email {user['email']} to unsubscribe")
+        print(f"No contact found for email {user_email} to unsubscribe")
         return
 
     contact_id = contact_ids[0]
@@ -159,4 +159,4 @@ def unsubscribe_user_from_news(user):
         [subscription_ids, {"opt_out": True}],
     )
 
-    print(f"User {user['email']} has been unsubscribed from mailing list {settings.ODOO_MAILING_LIST_ID}")
+    print(f"User {user_email} has been unsubscribed from mailing list {settings.ODOO_MAILING_LIST_ID}")


### PR DESCRIPTION
1. Removed `(optional)` from the text, since `I would like` already implies that it is an optional action.
2. Rewrote the code for passing `email` to `subscribe_user_to_news` and `unsubscribe_user_from_news` functions, since in some places the `User` object may be a dictionary or other object.

related: https://github.com/nextcloud/appstore/pull/1518