### PR TITLE
(fix): when registering with github "subscribe_to_news" should be false

### DIFF
--- a/nextcloudappstore/user/models.py
+++ b/nextcloudappstore/user/models.py
@@ -9,7 +9,7 @@ from .odoo import subscribe_user_to_news, unsubscribe_user_from_news
 class UserProfile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="profile")
     subscribe_to_news = models.BooleanField(
-        default=True, help_text="User has opted in to receive Nextcloud news and updates."
+        default=False, help_text="User has opted in to receive Nextcloud news and updates."
     )
 
     def __str__(self):


### PR DESCRIPTION
Missed this, currently `status` is True but subscription is not happening.

This should fix this by setting the default value for this field to False and the user will be able to subscribe from the settings later by checking the box.

Related: https://github.com/nextcloud/appstore/pull/1518