### PR TITLE
fix: subscribe user to news only after email confirmation

### DIFF
--- a/nextcloudappstore/user/forms.py
+++ b/nextcloudappstore/user/forms.py
@@ -11,8 +11,6 @@ from django.contrib.auth import get_user_model
 from django.forms import CharField, EmailField, PasswordInput
 from django.utils.translation import gettext_lazy as _
 
-from .odoo import subscribe_user_to_news
-
 
 class SignupFormRecaptcha(forms.Form):
     """integrate a recaptcha field."""
@@ -34,9 +32,6 @@ class SignupFormRecaptcha(forms.Form):
         # Set the subscription preference on the user's profile
         user.profile.subscribe_to_news = self.cleaned_data["subscribe_to_news"]
         user.profile.save()
-
-        if self.cleaned_data["subscribe_to_news"]:
-            subscribe_user_to_news(user.email, "")
 
 
 class DeleteAccountForm(forms.Form):


### PR DESCRIPTION
Victor correctly noted that the current algorithm subscribes the user to news if user ticked the checkbox, even if the user did not confirm the email, which is not correct.

This PR corrects the algorithm to be correct.


Note: *I will force a merge as CI is broken due to invalid translations*