### PR TITLE
fix CI: run docs actions on "ubuntu-22".04 instead of "ubuntu-latest"

### DIFF
--- a/.github/workflows/sphinxbuild.yml
+++ b/.github/workflows/sphinxbuild.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   appstore_docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -27,7 +27,6 @@ jobs:
     - name: Pack  the results in local tar file
       shell: bash
       run: tar czf /tmp/documentation.tar.gz -C docs/_build/html .
-
     - name: Upload static documentation
       uses: actions/upload-artifact@v4.4.0
       with:


### PR DESCRIPTION
Hope that this PR will eliminate this error from CI:


```
*** uWSGI linking ***
  /usr/bin/ld: cannot find -lpython3.10: No such file or directory
```