### PR TITLE
Enhance validation for "Download link (tar.gz)" field

### DIFF
--- a/nextcloudappstore/api/v1/tests/test_app_release.py
+++ b/nextcloudappstore/api/v1/tests/test_app_release.py
@@ -80,7 +80,9 @@ class AppReleaseTest(ApiTest):
 
     def test_create_unauthenticated(self):
         self.create_release(self.user)
-        response = self.api_client.post(self.create_url, data={"download": "https://download.com"}, format="json")
+        response = self.api_client.post(
+            self.create_url, data={"download": "https://download.com/somefile.tar.gz"}, format="json"
+        )
         self.assertEqual(401, response.status_code)
 
     @patch.object(AppReleaseProvider, "get_release_info")
@@ -93,7 +95,7 @@ class AppReleaseTest(ApiTest):
         response = self.api_client.post(
             self.create_url,
             data={
-                "download": "https://download.com",
+                "download": "https://download.com/somefile.tar.gz",
                 "signature": "sign",
             },
             format="json",
@@ -111,7 +113,7 @@ class AppReleaseTest(ApiTest):
             response = self.api_client.post(
                 self.create_url,
                 data={
-                    "download": "https://download.com",
+                    "download": "https://download.com/somefile.tar.gz",
                     "signature": "sign",
                 },
                 format="json",
@@ -127,7 +129,7 @@ class AppReleaseTest(ApiTest):
             response = self.api_client.post(
                 self.create_url,
                 data={
-                    "download": "https://download.com",
+                    "download": "https://download.com/somefile.tar.gz",
                     "signature": "sign",
                 },
                 format="json",
@@ -141,7 +143,7 @@ class AppReleaseTest(ApiTest):
         response = self.api_client.post(
             self.create_url,
             data={
-                "download": "http://download.com",
+                "download": "http://download.com/somefile.tar.gz",
                 "signature": "sign",
             },
             format="json",

--- a/nextcloudappstore/core/validators.py
+++ b/nextcloudappstore/core/validators.py
@@ -1,3 +1,7 @@
+import re
+from urllib.parse import unquote, urlparse
+
+from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.utils.translation import gettext_lazy as _  # type: ignore
 
@@ -7,3 +11,19 @@ class HttpsUrlValidator(URLValidator):
 
     def __init__(self):
         super().__init__(schemes=["https"])
+
+    def __call__(self, value):
+        # 1. Let Django's built-in URL checks run
+        super().__call__(value)
+
+        decoded_url = unquote(value)
+        parsed_url = urlparse(decoded_url)
+
+        # 2. Check for control characters:
+        # Null(\x00), Tab(\x09), Newline(\x0A), Carriage Return(\x0D), Escape(\x1B),DEL (\x7F)
+        if re.search(r"[\x00-\x1F\x7F]", decoded_url):
+            raise ValidationError(_("URL contains invalid (control) characters."))
+
+        # 3. Early enforcing of a .tar.gz extension
+        if not parsed_url.path.endswith(".tar.gz"):
+            raise ValidationError(_("URL must end with .tar.gz"))


### PR DESCRIPTION
PR enhances the validation for the “Download link (tar.gz)” field by introducing the following improvements:

1.	Added a check to ensure the URL does not contain invalid characters within the range `[\x00-\x1F]` + `\x7F`, which could cause unexpected behavior.
2.	Introduced an early check to ensure the URL ends with the `tar.gz` extension.
