### PR TITLE
fix: update top navigation bar layout for large viewport width

### DIFF
--- a/nextcloudappstore/core/static/assets/css/style.css
+++ b/nextcloudappstore/core/static/assets/css/style.css
@@ -244,7 +244,7 @@ body {
     align-items: center;
 }
 
-@media (max-width: 991px) {
+@media (max-width: 1199px) {
     .banner {
         max-height: 100%;
     }

--- a/nextcloudappstore/core/templates/nav.html
+++ b/nextcloudappstore/core/templates/nav.html
@@ -5,7 +5,7 @@
 <div class="banner">
     <div class="container">
         <div class="row row-no-gutters">
-            <div class="col-sm-12 col-md-6">
+            <div class="col-md-12 col-lg-6">
                 <div class="left-navbar-wrapper">
                     <a class="brand" href="/">
                         <img class="logo" alt="Logo" src="{% static 'assets/img/logo-icon.svg' %}" title="nextcloud.com">
@@ -77,7 +77,7 @@
                     </ul>
                 </div>
             </div>
-            <div class="col-sm-12 col-md-6">
+            <div class="col-md-12 col-lg-6">
                 <div id="navbar-wrapper" class="navbar-wrapper">
                     <div class="search-form">
                         <form method="get"


### PR DESCRIPTION
Fixes #1422. This displays the navigation elements on two rows rather than one to prevent the items being off-center with the presence of the admin button.

![Screenshot 2025-05-22 at 15-07-02 All apps - App Store - Nextcloud](https://github.com/user-attachments/assets/58eb1c81-77cd-4115-bfe1-dd7ecfb0c262)
