### PR TITLE
fix: remove custom password reset form

### DIFF
--- a/nextcloudappstore/settings/base.py
+++ b/nextcloudappstore/settings/base.py
@@ -155,7 +155,7 @@ ACCOUNT_FORMS = {
     "add_email": "allauth.account.forms.AddEmailForm",
     "change_password": "allauth.account.forms.ChangePasswordForm",
     "set_password": "allauth.account.forms.SetPasswordForm",
-    "reset_password": "nextcloudappstore.user.forms.CustomResetPasswordForm",
+    "reset_password": "allauth.account.forms.ResetPasswordForm",
     "reset_password_from_key": "allauth.account.forms.ResetPasswordKeyForm",
     "disconnect": "allauth.socialaccount.forms.DisconnectForm",
 }


### PR DESCRIPTION
No longer needed now that https://github.com/pennersr/django-allauth/issues/1307 is resolved.