### PR TITLE
fix: style password reset from email token success page

### DIFF
--- a/nextcloudappstore/core/templates/account/password_reset_from_key.html
+++ b/nextcloudappstore/core/templates/account/password_reset_from_key.html
@@ -5,9 +5,10 @@
 
 {% load css_class %}
 {% load i18n %}
+{% load allauth %}
 {% load account socialaccount %}
 
-{% block head-title %}{% trans "Log in" %} - {% endblock %}
+{% block head-title %}{% trans "Change Password" %} - {% endblock %}
 
 {% block content %}
 <div class="central-form">
@@ -17,36 +18,30 @@
         {% url 'account_reset_password' as passwd_reset_url %}
         <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
     {% else %}
-        {% if form %}
-            <form method="POST" action=".">
-                {% csrf_token %}
-                {% for field in form %}
-                <div class="form-group {% if field.errors %}has-error has-feedback{% endif %}">
-                    <label class="control-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+        <form method="POST" action=".">
+            {% csrf_token %}
+            {% for field in form %}
+            <div class="form-group {% if field.errors %}has-error has-feedback{% endif %}">
+                <label class="control-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
 
-                    {{ field|css_class:'form-control' }}
+                {{ field|css_class:'form-control' }}
 
-                    {% if field.errors %}
-                        {% for error in field.errors %}
-                            <span class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true"></span>
-                            <span class="sr-only">(error)</span>
-                            <p class="text-danger">{{ error|escape }}</p>
-                        {% endfor %}
-                    {% endif %}
+                {% if field.errors %}
+                    {% for error in field.errors %}
+                        <span class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true"></span>
+                        <span class="sr-only">(error)</span>
+                        <p class="text-danger">{{ error|escape }}</p>
+                    {% endfor %}
+                {% endif %}
 
-                    {% if field.help_text %}
-                        <p class="help-block">{{ field.help_text|safe }}</p>
-                    {% endif %}
+                {% if field.help_text %}
+                    <p class="help-block">{{ field.help_text|safe }}</p>
+                {% endif %}
 
-                </div>
-                {% endfor %}
-                <p><button class="btn btn-primary btn-block" type="submit">{% trans 'Change Password' %}</button></p>
-            </form>
-        {% else %}
-            <p>{% trans 'Your password is now changed.' %}</p>
-        {% endif %}
+            </div>
+            {% endfor %}
+            <p><button class="btn btn-primary btn-block" type="submit">{% trans 'Change Password' %}</button></p>
+        </form>
     {% endif %}
-
+</div>
 {% endblock %}
-
-

--- a/nextcloudappstore/core/templates/account/password_reset_from_key_done.html
+++ b/nextcloudappstore/core/templates/account/password_reset_from_key_done.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+
+{# SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors #}
+{# SPDX-License-Identifier: AGPL-3.0-or-later #}
+
+{% load css_class %}
+{% load i18n %}
+{% load account socialaccount %}
+
+{% block head-title %}{% trans "Log in" %} - {% endblock %}
+
+{% block content %}
+<div class="central-form">
+    <h1 class="text-center">{% if token_fail %}{% trans "Bad API Token" %}{% else %}{% trans "Change Password" %}{% endif %}</h1>
+    <hr>
+    {% if token_fail %}
+        {% url 'account_reset_password' as passwd_reset_url %}
+        <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
+    {% else %}
+        {% if form %}
+            <form method="POST" action=".">
+                {% csrf_token %}
+                {% for field in form %}
+                <div class="form-group {% if field.errors %}has-error has-feedback{% endif %}">
+                    <label class="control-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
+
+                    {{ field|css_class:'form-control' }}
+
+                    {% if field.errors %}
+                        {% for error in field.errors %}
+                            <span class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true"></span>
+                            <span class="sr-only">(error)</span>
+                            <p class="text-danger">{{ error|escape }}</p>
+                        {% endfor %}
+                    {% endif %}
+
+                    {% if field.help_text %}
+                        <p class="help-block">{{ field.help_text|safe }}</p>
+                    {% endif %}
+
+                </div>
+                {% endfor %}
+                <p><button class="btn btn-primary btn-block" type="submit">{% trans 'Change Password' %}</button></p>
+            </form>
+        {% else %}
+            <p>{% trans 'Your password is now changed.' %}</p>
+        {% endif %}
+    {% endif %}
+
+{% endblock %}
+
+

--- a/nextcloudappstore/core/templates/account/password_reset_from_key_done.html
+++ b/nextcloudappstore/core/templates/account/password_reset_from_key_done.html
@@ -5,48 +5,7 @@
 
 {% load css_class %}
 {% load i18n %}
+{% load allauth %}
 {% load account socialaccount %}
 
-{% block head-title %}{% trans "Log in" %} - {% endblock %}
-
-{% block content %}
-<div class="central-form">
-    <h1 class="text-center">{% if token_fail %}{% trans "Bad API Token" %}{% else %}{% trans "Change Password" %}{% endif %}</h1>
-    <hr>
-    {% if token_fail %}
-        {% url 'account_reset_password' as passwd_reset_url %}
-        <p>{% blocktrans %}The password reset link was invalid, possibly because it has already been used.  Please request a <a href="{{ passwd_reset_url }}">new password reset</a>.{% endblocktrans %}</p>
-    {% else %}
-        {% if form %}
-            <form method="POST" action=".">
-                {% csrf_token %}
-                {% for field in form %}
-                <div class="form-group {% if field.errors %}has-error has-feedback{% endif %}">
-                    <label class="control-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
-
-                    {{ field|css_class:'form-control' }}
-
-                    {% if field.errors %}
-                        {% for error in field.errors %}
-                            <span class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true"></span>
-                            <span class="sr-only">(error)</span>
-                            <p class="text-danger">{{ error|escape }}</p>
-                        {% endfor %}
-                    {% endif %}
-
-                    {% if field.help_text %}
-                        <p class="help-block">{{ field.help_text|safe }}</p>
-                    {% endif %}
-
-                </div>
-                {% endfor %}
-                <p><button class="btn btn-primary btn-block" type="submit">{% trans 'Change Password' %}</button></p>
-            </form>
-        {% else %}
-            <p>{% trans 'Your password is now changed.' %}</p>
-        {% endif %}
-    {% endif %}
-
-{% endblock %}
-
-
+{% block head-title %}{% trans "Change Password" %} - {% endblock %}


### PR DESCRIPTION
Fixes #1563. This adds a custom `password_reset_from_key_done.html` template which replaces the default template from allauth.

Currently, the new template is copied from `password_reset_from_key.html`, producing the following page:

![Screenshot 2025-05-27 at 14-14-14 Log in - App Store - Nextcloud](https://github.com/user-attachments/assets/64445efc-c99b-4a18-b36f-3b1e2f8508d0)

Additional styling may still be needed to remove the duplicate messages.