### PR TITLE
fix(models): bump minimum Nextcloud version for outdated app check

### DIFF
--- a/nextcloudappstore/core/models.py
+++ b/nextcloudappstore/core/models.py
@@ -403,7 +403,7 @@ class App(TranslatableModel):
         if not release_versions:
             return True
         max_release_version = max(map(lambda v: Version(pad_max_inc_version(v)), release_versions))
-        min_recent_version = Version(pad_min_version("27"))  # current Nextcloud version - 2
+        min_recent_version = Version(pad_min_version("30"))  # current Nextcloud version - 2
         return max_release_version < min_recent_version
 
     def _latest(self, releases):


### PR DESCRIPTION
Should've been updated after each new release, but better late than never. Later, we should figure out how to automate this by retrieving the latest version from somewhere.