### PR TITLE
docs: add maintenance status warning to production pages

### DIFF
--- a/docs/prodinstall.rst
+++ b/docs/prodinstall.rst
@@ -1,6 +1,13 @@
 Store Production Installation
 =============================
 
+.. warning::
+
+    Self-hosting the app store is not supported and we are not maintaining this part of the documentation.
+    As our code is open-source, you are welcome to reuse this part if you find a way to make it work, but such usage of the app store is at your own risk.
+    If you have a Nextcloud Enterprise subscription and you have special needs regarding self-hosting the app store,
+    please contact your account manager to talk about the possibilities.
+
 There are two ways to install the store, both are mutually exclusive (means: don't mix and match). If you are looking for a development setup, proceed to :doc:`devinstall`, otherwise continue.
 
 .. note:: This guide will use Ubuntu 22.04, Apache and PostgreSQL to set up the app store. You can of course also use different distributions and web-servers, however we will not be able to support you.

--- a/docs/prodinstalldocker.rst
+++ b/docs/prodinstalldocker.rst
@@ -2,6 +2,13 @@
 Store Production Install (Docker)
 =================================
 
+.. warning::
+
+    Self-hosting the app store is not supported and we are not maintaining this part of the code or documentation.
+    As our code is open-source, you are welcome to reuse this part of the code if you find a way to make it work, but such usage of the app store is at your own risk.
+    If you have a Nextcloud Enterprise subscription and you have special needs regarding self-hosting the app store,
+    please contact your account manager to talk about the possibilities.
+
 The App Store can be installed using `Docker <https://www.docker.com/>`_. This is still work in progress and therefore not recommended for production.
 
 Benefits and Drawbacks


### PR DESCRIPTION
<img width="870" height="276" alt="Screenshot 2026-04-20 at 14-18-06 Store Production Installation — AppStore 4 11 3 documentation" src="https://github.com/user-attachments/assets/46d30cfd-c703-4366-a13a-6ff62aee580c" />
<img width="870" height="338" alt="Screenshot 2026-04-20 at 14-18-38 Store Production Install (Docker) — AppStore 4 11 3 documentation" src="https://github.com/user-attachments/assets/88608055-16b5-4630-b65e-3aebce217efe" />
