### PR TITLE
feat(licenses): Adding Creative Commons Zero to the list of approved …

### DIFF
--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -342,6 +342,7 @@ licence
         * **AGPL-3.0-only**
         * **AGPL-3.0-or-later**
         * **Apache-2.0**
+        * **CC0-1.0**
         * **GPL-3.0-only**
         * **GPL-3.0-or-later**
         * **MIT**

--- a/nextcloudappstore/api/v1/release/info.xsd
+++ b/nextcloudappstore/api/v1/release/info.xsd
@@ -380,6 +380,7 @@
             <xs:enumeration value="AGPL-3.0-only"/>
             <xs:enumeration value="AGPL-3.0-or-later"/>
             <xs:enumeration value="Apache-2.0"/>
+            <xs:enumeration value="CC0-1.0"/>
             <xs:enumeration value="GPL-3.0-only"/>
             <xs:enumeration value="GPL-3.0-or-later"/>
             <xs:enumeration value="MIT"/>

--- a/nextcloudappstore/core/fixtures/licenses.json
+++ b/nextcloudappstore/core/fixtures/licenses.json
@@ -22,6 +22,13 @@
     },
     {
         "model": "core.license",
+        "pk": "CC0-1.0",
+        "fields": {
+            "name": "Creative Commons Zero v1.0 Universal"
+        }
+    },
+    {
+        "model": "core.license",
         "pk": "GPL-3.0-only",
         "fields": {
             "name": "GNU General Public License v3.0 only"


### PR DESCRIPTION
…licenses

Adds Creative Commons Zero (CC0-1.0) to the list of the approved licenses. This is the appstore part of the PR, there's an accompanying one placed on the server repo as well.

Solves #1746 