### PR TITLE
refactor(facades): add missing type parameters to generic functions

### DIFF
--- a/nextcloudappstore/core/facades.py
+++ b/nextcloudappstore/core/facades.py
@@ -66,11 +66,11 @@ T = TypeVar("T")
 U = TypeVar("U")
 
 
-def flatmap(f: Callable[[T], Iterable[U]], xs: Iterable[T]) -> Iterable[U]:
+def flatmap[T, U](f: Callable[[T], Iterable[U]], xs: Iterable[T]) -> Iterable[U]:
     return chain.from_iterable(map(f, xs))
 
 
-def all_match(predicate: Callable[[T], bool], iterable: Iterable[T]) -> bool:
+def all_match[T](predicate: Callable[[T], bool], iterable: Iterable[T]) -> bool:
     """
     :param predicate: function to test items
     :param iterable: iterable
@@ -79,7 +79,7 @@ def all_match(predicate: Callable[[T], bool], iterable: Iterable[T]) -> bool:
     return all(predicate(entry) for entry in iterable)
 
 
-def distinct(iterable: Iterable[T], criteria: Callable[[T], U]) -> Iterable[T]:
+def distinct[T, U](iterable: Iterable[T], criteria: Callable[[T], U]) -> Iterable[T]:
     """
     :param iterable:
     :param criteria: by default the object in the list. Pass a lambda to choose


### PR DESCRIPTION
Needed before updating pre-commit hooks (e.g. in #1678). This PR resolves the following errors in recent versions of `ruff`:

```
UP047 Generic function `flatmap` should use type parameters
  --> nextcloudappstore/core/facades.py:69:5
   |
69 | def flatmap(f: Callable[[T], Iterable[U]], xs: Iterable[T]) -> Iterable[U]:
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
70 |     return chain.from_iterable(map(f, xs))
   |
help: Use type parameters

UP047 Generic function `all_match` should use type parameters
  --> nextcloudappstore/core/facades.py:73:5
   |
73 | def all_match(predicate: Callable[[T], bool], iterable: Iterable[T]) -> bool:
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
74 |     """
75 |     :param predicate: function to test items
   |
help: Use type parameters

UP047 Generic function `distinct` should use type parameters
  --> nextcloudappstore/core/facades.py:82:5
   |
82 | def distinct(iterable: Iterable[T], criteria: Callable[[T], U]) -> Iterable[T]:
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
83 |     """
84 |     :param iterable:
   |
help: Use type parameters

Found 3 errors.
No fixes available (3 hidden fixes can be enabled with the `--unsafe-fixes` option).
```