### PR TITLE
fix(tests): make e2e language switch test resilient to translation churn

### DIFF
--- a/nextcloudappstore/core/tests/e2e/test_change_language.py
+++ b/nextcloudappstore/core/tests/e2e/test_change_language.py
@@ -24,5 +24,4 @@ class ChangeLanguageTest(BaseStoreTest):
         elem.submit()
 
         WebDriverWait(self.selenium, SELENIUM_WAIT_SEC).until(staleness_of(elem))
-        account_link = self.findNavigationLink("user:account")
-        self.assertEqual("person\nKonto", account_link.text)
+        self.assertEqual("de", self.by_css("html").get_attribute("lang"))


### PR DESCRIPTION
## Summary

The `Analysis & Coverage` workflow has been red on `master` for the last several pushes. The failure is in `test_change_lang`, which asserts that after switching the UI language to German, the navigation `Account` link reads `"person\nKonto"`. That assertion was silently coupled to the contents of `locale/de/LC_MESSAGES/django.po`, and a recent Transifex sync (commit d1cb4bfc89) wiped the `Account` msgstr — so the page now renders the English fallback and the test fails.

The test is meant to verify that the language-switch *mechanism* works, not that any particular string is translated. This PR replaces the text comparison with `assertEqual("de", self.by_css("html").get_attribute("lang"))`, which checks that Django activated the requested language on the next request. The test now passes regardless of how complete the German catalog is, and won't regress the next time the Transifex bot updates a translation.

## Test plan

- [x] `poetry run python manage.py test nextcloudappstore.core.tests.e2e.test_change_language` passes locally (headless Firefox)
- [x] `pre-commit` hooks (ruff, black, isort, flake8, bandit) pass on the modified file
- [x] CI `Analysis & Coverage` job goes green