### PR TITLE
fix(l10n): clear corrupted fa translation entries breaking compilemessages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix broken `fa` translation entries breaking `compilemessages` and CI.
+
 ## [4.11.3] - 2026-01-05
 
 ### Changed

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -766,14 +766,14 @@ msgid ""
 "To confirm this is correct, go to %(activate_url)s\n"
 "\n"
 "If you do not have an account at %(site_domain)s, simply ignore this message.\n"
-msgstr "با درود از %(site_name)s!"
+msgstr ""
 
 #: nextcloudappstore/core/templates/account/email/email_confirmation_message.txt:9
 #, python-format
 msgid ""
 "Thank you from the %(site_name)s!\n"
 "%(site_domain)s"
-msgstr "سپاس از شما از %(site_name)s!"
+msgstr ""
 
 #: nextcloudappstore/core/templates/account/email_confirm.html:9
 #: nextcloudappstore/core/templates/account/email_confirm.html:14
@@ -1763,7 +1763,7 @@ msgid ""
 "                <a href=\"https://nextcloudappstore.readthedocs.io/en/latest/restapi.html\">REST API</a>.\n"
 "                Make sure to keep it secret. A new token can be generated below, rendering the old token invalid.\n"
 "            "
-msgstr "از توکن API می‌توان برای احراز هویت هنگام فراخوانی "
+msgstr ""
 
 #: nextcloudappstore/user/templates/user/api-token.html:25
 msgid "Your API token is:"


### PR DESCRIPTION
## Summary
- CI (`test (postgres)` / `test (sqlite)`) has been failing on `master` since the automated Transifex sync commit `8c9115fe98` — `make dev-setup` → `make l10n` → `django-admin compilemessages` aborts with `msgfmt: found 4 fatal errors` before any test runs.
- Root cause: three corrupted entries in `locale/fa/LC_MESSAGES/django.po`, not an encoding or RTL issue — the Farsi text itself is valid UTF-8 and other entries in the file compile fine:
  - `locale/fa/LC_MESSAGES/django.po:769` — `msgid`/`msgstr` disagree on trailing `\n`
  - `locale/fa/LC_MESSAGES/django.po:776` — `msgstr` is missing the `%(site_domain)s` format placeholder present in `msgid`
  - `locale/fa/LC_MESSAGES/django.po:1766` — `msgid`/`msgstr` disagree on leading `\n`
- These look like partial/truncated translations that landed via the Transifex sync bot. Rather than fabricate corrected Farsi text, this clears the three broken `msgstr` entries so they fall back to the English `msgid` (valid, untranslated gettext entries) until Transifex resupplies clean translations on its next sync.
- Swept every other `locale/*/LC_MESSAGES/django.po` file with `msgfmt -c` — no other locale has this issue.

## Test plan
- [x] `msgfmt -c -v -o /dev/null locale/fa/LC_MESSAGES/django.po` — 0 fatal errors (previously 4)
- [x] `python manage.py compilemessages --settings nextcloudappstore.settings.development` — completes without error across all locales
- [x] `for f in locale/*/LC_MESSAGES/django.po; do msgfmt -c -o /dev/null "$f"; done` — no fatal errors in any locale

🤖 Generated with [Claude Code](https://claude.com/claude-code)