### PR TITLE
fix(settings): trust reverse proxy for client IP in rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Trust the reverse proxy's `X-Forwarded-For` header for login rate limiting, so failed-login limits apply per visitor instead of collapsing into a single site-wide bucket. #1813
 - Fix broken `fa` translation entries breaking `compilemessages` and CI. #1812
 - Reject app IDs longer than 32 characters during upload instead of letting Nextcloud server crash on install. #1809
 

--- a/nextcloudappstore/settings/base.py
+++ b/nextcloudappstore/settings/base.py
@@ -139,6 +139,12 @@ ACCOUNT_RATE_LIMITS = {
     "manage_email": "3/h/user",
 }
 
+# We run behind a single reverse proxy, which sets X-Forwarded-For. Without
+# this, allauth's rate limiting (e.g. ACCOUNT_RATE_LIMITS["login_failed"]
+# above) falls back to REMOTE_ADDR, which is the proxy's own address for
+# every request -- collapsing per-IP limits into a single site-wide bucket.
+ALLAUTH_TRUSTED_PROXY_COUNT = 1
+
 SITE_ID = 1
 
 # Allauth configuration


### PR DESCRIPTION
## Summary
- `mod_wsgi` logs show every request's `REMOTE_ADDR` as `127.0.0.1` — there's a reverse proxy in front of Apache that isn't being accounted for by the app.
- `django-allauth`'s rate limiter (backing `ACCOUNT_RATE_LIMITS["login_failed"]`) resolves the client IP via `allauth.core.internal.httpkit.get_client_ip()`, which only trusts `X-Forwarded-For` when `ALLAUTH_TRUSTED_PROXY_COUNT > 0`. That setting wasn't set anywhere, so it fell back to `REMOTE_ADDR` — i.e. the proxy's own address for every visitor.
- Net effect: the per-IP `login_failed: "10/h/ip"` limit collapsed into a single **site-wide** bucket of 10 failed password attempts per hour, shared by every user. Once exhausted (typos, scanners, credential stuffing — trivial to trigger), every regular username/password login got rejected with 429 until the hour rolled over, while GitHub OAuth — a separate code path with no rate limiter — kept working. This matches reports of "GitHub login works, regular login doesn't."
- Confirmed with sysadmins: there's exactly one reverse-proxy hop in front of Apache, and `X-Forwarded-For` is reliably populated with the real client IP in this deployment (an existing ops-side logging filter for `bad_requests.log`/fail2ban already depends on it).
- Fix: set `ALLAUTH_TRUSTED_PROXY_COUNT = 1` so allauth resolves the real client IP from the trusted hop of `X-Forwarded-For` instead of `REMOTE_ADDR`, restoring per-visitor rate limiting.

## Test plan
- [x] `python -c "... from allauth import app_settings; print(app_settings.TRUSTED_PROXY_COUNT)"` → confirms `1` is picked up from settings.
- [ ] Post-deploy: verify a burst of failed logins from one real client IP no longer blocks unrelated users' logins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)