### PR TITLE
fix(release): add IP filtering to app release URLs

### DIFF
--- a/nextcloudappstore/api/v1/release/downloader.py
+++ b/nextcloudappstore/api/v1/release/downloader.py
@@ -8,6 +8,7 @@ import tempfile
 from typing import Any
 
 import requests
+from requests_hardened import Config, Manager
 from rest_framework.exceptions import ValidationError  # type: ignore
 
 from nextcloudappstore.api.v1.release.parser import UnsupportedAppArchiveException
@@ -62,8 +63,19 @@ class AppReleaseDownloader:
         else:
             os.makedirs(target_directory, mode=0o700, exist_ok=True)
             file = tempfile.NamedTemporaryFile(dir=target_directory, delete=False)
+
         try:
-            with requests.Session() as session:
+            http_manager = Manager(
+                Config(
+                    default_timeout=(timeout, timeout),
+                    never_redirect=False,
+                    ip_filter_enable=True,
+                    ip_filter_allow_loopback_ips=False,
+                    user_agent_override=None,
+                )
+            )
+
+            with http_manager.get_session() as session:
                 session.max_redirects = max_redirects
                 req = session.get(url, stream=True, timeout=timeout)
                 req.raise_for_status()

--- a/nextcloudappstore/api/v1/tests/__init__.py
+++ b/nextcloudappstore/api/v1/tests/__init__.py
@@ -7,5 +7,6 @@ from .test_app import *
 from .test_app_register import *
 from .test_app_release import *
 from .test_app_release_provider import *
+from .test_downloader import *
 from .test_parser import *
 from .test_release_importer import *

--- a/nextcloudappstore/api/v1/tests/test_downloader.py
+++ b/nextcloudappstore/api/v1/tests/test_downloader.py
@@ -1,0 +1,92 @@
+"""
+SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+
+import http.server
+import ipaddress
+import shutil
+import socket
+import tempfile
+import threading
+
+from django.test import SimpleTestCase
+
+from nextcloudappstore.api.v1.release.downloader import AppReleaseDownloader
+from nextcloudappstore.api.v1.release.parser import UnsupportedAppArchiveException
+
+
+class _SilentHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        body = b"x" * 16
+        self.send_response(200)
+        self.send_header("Content-Type", "application/gzip")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        pass
+
+
+def _get_local_ip():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sock.connect(("8.8.8.8", 80))
+        return sock.getsockname()[0]
+    except OSError:
+        return None
+    finally:
+        sock.close()
+
+
+class AppReleaseDownloaderTest(SimpleTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.httpd = http.server.HTTPServer(("0.0.0.0", 0), _SilentHandler)
+        cls.port = cls.httpd.server_address[1]
+        cls.server_thread = threading.Thread(target=cls.httpd.serve_forever, daemon=True)
+        cls.server_thread.start()
+        cls.local_ip = _get_local_ip()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+        cls.server_thread.join()
+        super().tearDownClass()
+
+    def setUp(self):
+        self.downloader = AppReleaseDownloader()
+        self.target_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.target_dir, ignore_errors=True)
+
+    def _assert_blocked(self, url):
+        with self.assertRaises(UnsupportedAppArchiveException):
+            self.downloader.get_archive(url, target_directory=self.target_dir, timeout=10)
+
+    def test_loopback_ipv4_blocked(self):
+        self._assert_blocked(f"http://127.0.0.1:{self.port}/app.tar.gz")
+
+    def test_loopback_hostname_blocked(self):
+        self._assert_blocked(f"http://localhost:{self.port}/app.tar.gz")
+
+    def test_machine_local_ip_blocked(self):
+        if not self.local_ip:
+            self.skipTest("could not discover a local IP address")
+        ip = ipaddress.ip_address(self.local_ip)
+        if not ip.is_private:
+            self.skipTest(f"discovered IP {self.local_ip} is not private")
+        self._assert_blocked(f"http://{self.local_ip}:{self.port}/app.tar.gz")
+
+    def test_private_ip_range_192_168_blocked(self):
+        self._assert_blocked("http://192.168.1.1:1/app.tar.gz")
+
+    def test_private_ip_range_10_blocked(self):
+        self._assert_blocked("http://10.0.0.1:1/app.tar.gz")
+
+    def test_private_ip_range_172_16_blocked(self):
+        self._assert_blocked("http://172.16.0.1:1/app.tar.gz")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1821,6 +1821,21 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
+name = "requests-hardened"
+version = "1.2.2"
+description = "A library that overrides the default behaviors of the requests library, and adds new security features."
+optional = false
+python-versions = "<4.0,>=3.10"
+groups = ["main"]
+files = [
+    {file = "requests_hardened-1.2.2-py3-none-any.whl", hash = "sha256:0bf87b1c72fdb761b9643f8c91c059262bb825af55011fab55547397a401740c"},
+    {file = "requests_hardened-1.2.2.tar.gz", hash = "sha256:f9a479bf097a8debeade1643b4777669161ed98c8a4a12a4d19fa008bc6ae5ea"},
+]
+
+[package.dependencies]
+requests = ">=2.32.3,<3.0.0"
+
+[[package]]
 name = "responses"
 version = "0.26.2"
 description = "A utility library for mocking out the `requests` Python library."
@@ -2307,4 +2322,4 @@ h11 = ">=0.16.0,<1"
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12"
-content-hash = "774b4f3c8e145e3d068020aa41e2cb35c083d4863aefbcb23e689dc5f78965a5"
+content-hash = "67f1e53d43f087eb5aa314c25b8f40483f992c0ea1c4675794e19fba7f407537"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies.redis = { version = "^8.0.0", extras = [
   "hiredis",
 ] }
 dependencies.requests = ">=2.34.2, <2.35.0"
+dependencies.requests-hardened = "^1.2.2"
 dependencies.semantic-version = "^2.8.5"
 dependencies.uWSGI = "^2.0.20"
 dev-dependencies.coverage = "*"


### PR DESCRIPTION
Replaces the `requests` package with the `requests_hardened` package in the app release upload endpoint, adding additional validation to the app release URLs submitted by app maintainers. With this change, the console log now includes entries such as:

```
Forbidden IP address: 192.168.1.1 for hostname 192.168.1.1
Bad Request: /api/v1/apps/releases
"POST /api/v1/apps/releases HTTP/1.1" 400 49
```

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
