### PR TITLE
feat!(api): validate subscription key before retrieving enterprise-only apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Replace `include_enterprise` query parameter with `subscription_key` parameter for retrieval of enterprise-only apps. #1848
+
 ## [4.12.0] - 2026-08-05
 
 ### Added

--- a/docs/api/restapi.rst
+++ b/docs/api/restapi.rst
@@ -270,7 +270,7 @@ This route will return all releases to display inside Nextcloud's apps admin are
 
 * **Query parameters**:
 
-  * **include_enterprise**: boolean: Whether or not to include apps marked as enterprise-only. Defaults to false
+  * **subscription_key**: string: Nextcloud Enterprise subscription key. If it is valid, enterprise-only apps will also be returned.
 
 * **Authentication**: None
 
@@ -483,7 +483,7 @@ This route will return all releases to display inside Nextcloud's apps admin are
 * **Url**: GET /api/v1/apps.json
 * **Query parameters**:
 
-  * **include_enterprise**: boolean: Whether or not to include apps marked as enterprise-only. Defaults to false
+  * **subscription_key**: string: Nextcloud Enterprise subscription key. If it is valid, enterprise-only apps will also be returned.
 
 * **Authentication**: None
 

--- a/nextcloudappstore/api/v1/tests/test_app.py
+++ b/nextcloudappstore/api/v1/tests/test_app.py
@@ -3,6 +3,8 @@ SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
 SPDX-License-Identifier: AGPL-3.0-or-later
 """
 
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
@@ -31,21 +33,23 @@ class AppTest(ApiTest):
         self.assertIn("news", ids)
         self.assertNotIn("enterprise", ids)
 
-    def test_apps_excludes_enterprise_when_false(self):
+    def test_apps_excludes_enterprise_with_invalid_key(self):
         self._create_app_with_release("news")
         self._create_app_with_release("enterprise", is_enterprise_only=True)
         url = reverse("api:v1:apps")
-        response = self.api_client.get(url, {"include_enterprise": "false"})
+        with patch("nextcloudappstore.core.enterprise.validate_subscription_key", return_value=False):
+            response = self.api_client.get(url, {"subscription_key": "invalid"})
         self.assertEqual(200, response.status_code)
         ids = [app["id"] for app in response.data]
         self.assertIn("news", ids)
         self.assertNotIn("enterprise", ids)
 
-    def test_apps_includes_enterprise_when_requested(self):
+    def test_apps_includes_enterprise_with_valid_key(self):
         self._create_app_with_release("news")
         self._create_app_with_release("enterprise", is_enterprise_only=True)
         url = reverse("api:v1:apps")
-        response = self.api_client.get(url, {"include_enterprise": "true"})
+        with patch("nextcloudappstore.core.enterprise.validate_subscription_key", return_value=True):
+            response = self.api_client.get(url, {"subscription_key": "valid"})
         self.assertEqual(200, response.status_code)
         ids = [app["id"] for app in response.data]
         self.assertIn("news", ids)
@@ -61,11 +65,12 @@ class AppTest(ApiTest):
         self.assertIn("news", ids)
         self.assertNotIn("enterprise", ids)
 
-    def test_platform_includes_enterprise_when_requested(self):
+    def test_platform_includes_enterprise_with_valid_key(self):
         self._create_app_with_release("news")
         self._create_app_with_release("enterprise", is_enterprise_only=True)
         url = reverse("api:v1:app", kwargs={"version": "9.1.1"})
-        response = self.api_client.get(url, {"include_enterprise": "true"})
+        with patch("nextcloudappstore.core.enterprise.validate_subscription_key", return_value=True):
+            response = self.api_client.get(url, {"subscription_key": "valid"})
         self.assertEqual(200, response.status_code)
         ids = [app["id"] for app in response.data]
         self.assertIn("news", ids)
@@ -81,11 +86,12 @@ class AppTest(ApiTest):
         self.assertIn("news", ids)
         self.assertNotIn("enterprise", ids)
 
-    def test_appapi_includes_enterprise_when_requested(self):
+    def test_appapi_includes_enterprise_with_valid_key(self):
         self._create_app_with_release("news", aa_is_system=False)
         self._create_app_with_release("enterprise", is_enterprise_only=True, aa_is_system=False)
         url = reverse("api:v1:appapi_apps")
-        response = self.api_client.get(url, {"include_enterprise": "true"})
+        with patch("nextcloudappstore.core.enterprise.validate_subscription_key", return_value=True):
+            response = self.api_client.get(url, {"subscription_key": "valid"})
         self.assertEqual(200, response.status_code)
         ids = [app["id"] for app in response.data]
         self.assertIn("news", ids)

--- a/nextcloudappstore/api/v1/views.py
+++ b/nextcloudappstore/api/v1/views.py
@@ -38,7 +38,7 @@ from nextcloudappstore.api.v1.serializers import (
     NextcloudReleaseSerializer,
 )
 from nextcloudappstore.certificate.validator import CertificateValidator
-from nextcloudappstore.core.caching import filter_enterprise, include_enterprise
+from nextcloudappstore.core.enterprise import enterprise_enabled, filter_enterprise
 from nextcloudappstore.core.facades import read_file_contents
 from nextcloudappstore.core.models import (
     App,
@@ -84,7 +84,7 @@ AA_APP_PREFETCH_LIST = [
 
 
 class EnterpriseFilterMixin:
-    """Filter out enterprise-only apps unless include_enterprise is set."""
+    """Filter out enterprise-only apps unless a valid subscription key is provided."""
 
     def get_queryset(self):
         return filter_enterprise(super().get_queryset(), self.request)
@@ -136,7 +136,7 @@ class AppView(DestroyAPIView):
     def get(self, request, *args, **kwargs):
         version = self.kwargs["version"]
         working_apps = App.objects.get_compatible(version, prefetch=APP_PREFETCH_LIST)
-        if not include_enterprise(request):
+        if not enterprise_enabled(request):
             working_apps = [app for app in working_apps if not app.is_enterprise_only]
         serializer = self.get_serializer(working_apps, many=True)
         data = self._filter_releases(serializer.data, version)

--- a/nextcloudappstore/core/caching.py
+++ b/nextcloudappstore/core/caching.py
@@ -11,6 +11,7 @@ from django.conf import settings  # type: ignore
 from django.db.models import Max, QuerySet
 from semantic_version import Version
 
+from nextcloudappstore.core.enterprise import filter_enterprise
 from nextcloudappstore.core.models import (
     App,
     AppRating,
@@ -42,7 +43,7 @@ def get_last_modified(pairs: list[tuple[QuerySet, str]]) -> datetime.datetime | 
 def apps_etag(request: Any, version: str) -> str:
     return create_etag(
         [
-            (_apps_for_request(request), "last_release"),
+            (filter_enterprise(App.objects.all(), request), "last_release"),
             (AppReleaseDeleteLog.objects.all(), "last_modified"),
         ]
     )
@@ -51,32 +52,16 @@ def apps_etag(request: Any, version: str) -> str:
 def apps_last_modified(request: Any, version: str) -> datetime.datetime | None:
     return get_last_modified(
         [
-            (_apps_for_request(request), "last_release"),
+            (filter_enterprise(App.objects.all(), request), "last_release"),
             (AppReleaseDeleteLog.objects.all(), "last_modified"),
         ]
     )
 
 
-def include_enterprise(request: Any) -> bool:
-    return request.GET.get("include_enterprise", "").lower() in ("true", "1")
-
-
-def filter_enterprise(queryset: QuerySet, request: Any) -> QuerySet:
-    """Filter out enterprise-only apps unless include_enterprise is set."""
-    if not include_enterprise(request):
-        queryset = queryset.filter(is_enterprise_only=False)
-    return queryset
-
-
-def _apps_for_request(request: Any) -> QuerySet:
-    """App queryset scoped to the representation selected by include_enterprise."""
-    return filter_enterprise(App.objects.all(), request)
-
-
 def apps_all_etag(request: Any) -> str:
     return create_etag(
         [
-            (_apps_for_request(request), "last_release"),
+            (filter_enterprise(App.objects.all(), request), "last_release"),
             (AppReleaseDeleteLog.objects.all(), "last_modified"),
         ]
     )
@@ -85,7 +70,7 @@ def apps_all_etag(request: Any) -> str:
 def apps_all_last_modified(request: Any) -> datetime.datetime | None:
     return get_last_modified(
         [
-            (_apps_for_request(request), "last_release"),
+            (filter_enterprise(App.objects.all(), request), "last_release"),
             (AppReleaseDeleteLog.objects.all(), "last_modified"),
         ]
     )

--- a/nextcloudappstore/core/enterprise.py
+++ b/nextcloudappstore/core/enterprise.py
@@ -1,0 +1,53 @@
+"""
+SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+
+import logging
+
+import requests
+from django.conf import settings
+from django.db.models import QuerySet
+
+logger = logging.getLogger(__name__)
+
+VALIDATION_TIMEOUT = 10  # seconds
+
+
+def is_enterprise_feature_enabled() -> bool:
+    return bool(
+        getattr(settings, "ENABLE_ENTERPRISE_ONLY_APPS", False)
+        and getattr(settings, "ENTERPRISE_KEY_VALIDATION_ENDPOINT", "")
+        and getattr(settings, "ENTERPRISE_KEY_VALIDATION_API_KEY", "")
+    )
+
+
+def validate_subscription_key(subscription_key: str) -> bool:
+    if not is_enterprise_feature_enabled() or not subscription_key:
+        return False
+    try:
+        response = requests.post(
+            settings.ENTERPRISE_KEY_VALIDATION_ENDPOINT,
+            json={"subscriptionKey": subscription_key},
+            headers={"Authorization": f"Bearer {settings.ENTERPRISE_KEY_VALIDATION_API_KEY}"},
+            timeout=VALIDATION_TIMEOUT,
+        )
+        response.raise_for_status()
+        return bool(response.json().get("valid", False))
+    except (requests.RequestException, ValueError):
+        logger.warning("Failed to validate enterprise subscription key", exc_info=True)
+        return False
+
+
+def enterprise_enabled(request) -> bool:
+    if not hasattr(request, "_enterprise_enabled"):
+        subscription_key = request.GET.get("subscription_key", "")
+        request._enterprise_enabled = validate_subscription_key(subscription_key)
+    return request._enterprise_enabled
+
+
+def filter_enterprise(queryset: QuerySet, request) -> QuerySet:
+    """Filter out enterprise-only apps unless a valid subscription key is provided."""
+    if not enterprise_enabled(request):
+        queryset = queryset.filter(is_enterprise_only=False)
+    return queryset

--- a/nextcloudappstore/core/enterprise.py
+++ b/nextcloudappstore/core/enterprise.py
@@ -1,0 +1,52 @@
+"""
+SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+SPDX-License-Identifier: AGPL-3.0-or-later
+"""
+
+import logging
+
+import requests
+from django.conf import settings
+from django.db.models import QuerySet
+
+logger = logging.getLogger(__name__)
+
+VALIDATION_TIMEOUT = 10  # seconds
+
+
+def is_enterprise_feature_enabled() -> bool:
+    return bool(
+        getattr(settings, "ENABLE_ENTERPRISE_ONLY_APPS", False)
+        and getattr(settings, "ENTERPRISE_KEY_VALIDATION_ENDPOINT", "")
+        and getattr(settings, "ENTERPRISE_KEY_VALIDATION_API_KEY", "")
+    )
+
+
+def validate_subscription_key(subscription_key: str) -> bool:
+    if not is_enterprise_feature_enabled() or not subscription_key:
+        return False
+    try:
+        response = requests.post(
+            settings.ENTERPRISE_KEY_VALIDATION_ENDPOINT,
+            json={"apiKey": settings.ENTERPRISE_KEY_VALIDATION_API_KEY, "subscriptionKey": subscription_key},
+            timeout=VALIDATION_TIMEOUT,
+        )
+        response.raise_for_status()
+        return bool(response.json().get("valid", False))
+    except (requests.RequestException, ValueError):
+        logger.warning("Failed to validate enterprise subscription key", exc_info=True)
+        return False
+
+
+def enterprise_enabled(request) -> bool:
+    if not hasattr(request, "_enterprise_enabled"):
+        subscription_key = request.GET.get("subscription_key", "")
+        request._enterprise_enabled = validate_subscription_key(subscription_key)
+    return request._enterprise_enabled
+
+
+def filter_enterprise(queryset: QuerySet, request) -> QuerySet:
+    """Filter out enterprise-only apps unless a valid subscription key is provided."""
+    if not enterprise_enabled(request):
+        queryset = queryset.filter(is_enterprise_only=False)
+    return queryset

--- a/nextcloudappstore/core/tests/test_caching.py
+++ b/nextcloudappstore/core/tests/test_caching.py
@@ -4,6 +4,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 """
 
 import datetime
+from unittest.mock import patch
 from urllib.request import Request
 
 from django.contrib.auth.models import User
@@ -55,13 +56,16 @@ class AppsCachingTestBase(TestCase):
         self.t1 = timezone.now()
         self.app = App.objects.create(id="news", owner=self.user, last_release=self.t1)
 
-    def _request(self, include_enterprise=None):
-        data = {"include_enterprise": include_enterprise} if include_enterprise is not None else {}
+    def _request(self, subscription_key=None):
+        data = {"subscription_key": subscription_key} if subscription_key is not None else {}
         return self.factory.get("/apps.json", data)
 
     def _create_enterprise_app(self):
         t2 = self.t1 + datetime.timedelta(hours=1)
         return App.objects.create(id="ent", owner=self.user, is_enterprise_only=True, last_release=t2)
+
+    def _patch_valid_key(self):
+        return patch("nextcloudappstore.core.enterprise.validate_subscription_key", return_value=True)
 
 
 class AppsAllCachingTest(AppsCachingTestBase):
@@ -71,34 +75,39 @@ class AppsAllCachingTest(AppsCachingTestBase):
         default_etag = apps_all_etag(self._request())
         self.assertEqual(str(self.t1), default_etag)
 
-    def test_etag_includes_enterprise_only_apps_when_requested(self):
+    def test_etag_includes_enterprise_only_apps_with_valid_key(self):
         ent = self._create_enterprise_app()
 
-        enterprise_etag = apps_all_etag(self._request("true"))
+        with self._patch_valid_key():
+            enterprise_etag = apps_all_etag(self._request("valid"))
         self.assertEqual(str(ent.last_release), enterprise_etag)
 
     def test_enterprise_app_change_does_not_bust_default_etag(self):
         default_before = apps_all_etag(self._request())
-        enterprise_before = apps_all_etag(self._request("true"))
+        with self._patch_valid_key():
+            enterprise_before = apps_all_etag(self._request("valid"))
 
         self._create_enterprise_app()
 
         default_after = apps_all_etag(self._request())
-        enterprise_after = apps_all_etag(self._request("true"))
+        with self._patch_valid_key():
+            enterprise_after = apps_all_etag(self._request("valid"))
 
         self.assertEqual(default_before, default_after)
         self.assertNotEqual(enterprise_before, enterprise_after)
 
     def test_non_enterprise_app_change_busts_both_etags(self):
         default_before = apps_all_etag(self._request())
-        enterprise_before = apps_all_etag(self._request("true"))
+        with self._patch_valid_key():
+            enterprise_before = apps_all_etag(self._request("valid"))
 
         t2 = self.t1 + datetime.timedelta(hours=1)
         self.app.last_release = t2
         self.app.save()
 
         default_after = apps_all_etag(self._request())
-        enterprise_after = apps_all_etag(self._request("true"))
+        with self._patch_valid_key():
+            enterprise_after = apps_all_etag(self._request("valid"))
 
         self.assertNotEqual(default_before, default_after)
         self.assertNotEqual(enterprise_before, enterprise_after)
@@ -108,10 +117,12 @@ class AppsAllCachingTest(AppsCachingTestBase):
 
         self.assertEqual(self.t1, apps_all_last_modified(self._request()))
 
-    def test_last_modified_includes_enterprise_only_apps_when_requested(self):
+    def test_last_modified_includes_enterprise_only_apps_with_valid_key(self):
         ent = self._create_enterprise_app()
 
-        self.assertEqual(ent.last_release, apps_all_last_modified(self._request("true")))
+        with self._patch_valid_key():
+            result = apps_all_last_modified(self._request("valid"))
+        self.assertEqual(ent.last_release, result)
 
 
 class AppsPlatformCachingTest(AppsCachingTestBase):
@@ -122,26 +133,32 @@ class AppsPlatformCachingTest(AppsCachingTestBase):
 
         self.assertEqual(str(self.t1), apps_etag(self._request(), "9.1.1"))
 
-    def test_etag_includes_enterprise_only_apps_when_requested(self):
+    def test_etag_includes_enterprise_only_apps_with_valid_key(self):
         ent = self._create_enterprise_app()
 
-        self.assertEqual(str(ent.last_release), apps_etag(self._request("true"), "9.1.1"))
+        with self._patch_valid_key():
+            result = apps_etag(self._request("valid"), "9.1.1")
+        self.assertEqual(str(ent.last_release), result)
 
     def test_enterprise_app_change_does_not_bust_default_etag(self):
         default_before = apps_etag(self._request(), "9.1.1")
-        enterprise_before = apps_etag(self._request("true"), "9.1.1")
+        with self._patch_valid_key():
+            enterprise_before = apps_etag(self._request("valid"), "9.1.1")
 
         self._create_enterprise_app()
 
         self.assertEqual(default_before, apps_etag(self._request(), "9.1.1"))
-        self.assertNotEqual(enterprise_before, apps_etag(self._request("true"), "9.1.1"))
+        with self._patch_valid_key():
+            self.assertNotEqual(enterprise_before, apps_etag(self._request("valid"), "9.1.1"))
 
     def test_last_modified_excludes_enterprise_only_apps_by_default(self):
         self._create_enterprise_app()
 
         self.assertEqual(self.t1, apps_last_modified(self._request(), "9.1.1"))
 
-    def test_last_modified_includes_enterprise_only_apps_when_requested(self):
+    def test_last_modified_includes_enterprise_only_apps_with_valid_key(self):
         ent = self._create_enterprise_app()
 
-        self.assertEqual(ent.last_release, apps_last_modified(self._request("true"), "9.1.1"))
+        with self._patch_valid_key():
+            result = apps_last_modified(self._request("valid"), "9.1.1")
+        self.assertEqual(ent.last_release, result)

--- a/nextcloudappstore/settings/base.py
+++ b/nextcloudappstore/settings/base.py
@@ -387,6 +387,11 @@ NEXTCLOUD_INTEGRATIONS_APPROVAL_EMAILS = ["marketing-team@nextcloud.com"]
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 
+# Enterprise-only apps configuration
+ENABLE_ENTERPRISE_ONLY_APPS = False
+ENTERPRISE_KEY_VALIDATION_ENDPOINT = ""
+ENTERPRISE_KEY_VALIDATION_API_KEY = ""
+
 # Do not fill in these values here, use the "development.py" or "production.py" files.
 ODOO_URL = ""
 ODOO_DB = ""


### PR DESCRIPTION
Part 2 implementation of #1785. This replaces the `include_enterprise` toggle previously implemented in #1840.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
