### PR TITLE
fix: convert app screenshot URLs to user content proxy URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Retrieve app screenshots from proxy server instead of direct URLs specified by apps. #1862
 - Replace `include_enterprise` query parameter with `subscription_key` parameter for retrieval of enterprise-only apps. #1848
 
 ## [4.12.0] - 2026-08-05

--- a/nextcloudappstore/api/v1/release/importer.py
+++ b/nextcloudappstore/api/v1/release/importer.py
@@ -4,6 +4,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 """
 
 import json
+from base64 import urlsafe_b64encode
 from typing import Any  # type: ignore
 
 from django.conf import settings  # type: ignore
@@ -139,9 +140,13 @@ class StringAttributeImporter(ScalarImporter):
 
 class ScreenshotsImporter(ScalarImporter):
     def import_data(self, key: str, value: Any, obj: Any) -> None:
+        def get_proxy_url(url: str) -> str:
+            base64_url = urlsafe_b64encode(url.encode()).decode()
+            return f"{settings.USERCONTENT_PROXY_URL}/{base64_url}"
+
         def create_screenshot(img: dict[str, str]) -> Screenshot:
             return Screenshot.objects.create(
-                url=img["url"],
+                url=get_proxy_url(img["url"]),
                 app=obj,
                 ordering=img["ordering"],
                 small_thumbnail=none_to_empty_string(img["small_thumbnail"]),

--- a/nextcloudappstore/core/migrations/0037_convert_screenshot_urls_to_usercontent.py
+++ b/nextcloudappstore/core/migrations/0037_convert_screenshot_urls_to_usercontent.py
@@ -1,0 +1,34 @@
+#SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+#SPDX-License-Identifier: AGPL-3.0-or-later
+
+from base64 import urlsafe_b64encode
+
+from django.db import migrations
+
+
+def convert_screenshot_urls_to_usercontent(apps, schema_editor):
+    from django.conf import settings
+
+    Screenshot = apps.get_model('core', 'Screenshot')
+    base = settings.USERCONTENT_PROXY_URL
+    for screenshot in Screenshot.objects.all():
+        url = screenshot.url
+        if not url or url.startswith(base):
+            continue
+        base64_url = urlsafe_b64encode(url.encode()).decode()
+        screenshot.url = f"{base}/{base64_url}"
+        screenshot.save(update_fields=['url'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0036_app_is_enterprise_only'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            convert_screenshot_urls_to_usercontent,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/nextcloudappstore/settings/base.py
+++ b/nextcloudappstore/settings/base.py
@@ -304,6 +304,9 @@ MAX_DOWNLOAD_REDIRECTS = 10
 MAX_DOWNLOAD_SIZE = 30 * (1024**2)  # bytes
 ARCHIVE_FOLDER_BLACKLIST = {"No .git directories": r"\.git$"}
 
+# proxy server URL for caching app screenshots
+USERCONTENT_PROXY_URL = "https://usercontent.apps.nextcloud.com"
+
 # certificate location configuration
 NEXTCLOUD_CERTIFICATE_LOCATION = BASE_DIR / "certificate/nextcloud.crt"
 NEXTCLOUD_CRL_LOCATION = BASE_DIR / "certificate/nextcloud.crl"


### PR DESCRIPTION
This allows the App Store to retrieve all app screenshots from the proxy server rather than directly from their original sources. Also included is a database migration to convert already stored screenshot URLs to equivalent URLs in the proxy server.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
