### PR TITLE
feat!(api): replace `subscription_key` query parameter with `X-NC-Subscription-Key` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changed
 
 - Retrieve app screenshots from proxy server instead of direct URLs specified by apps. #1862
-- Replace `include_enterprise` query parameter with `subscription_key` parameter for retrieval of enterprise-only apps. #1848
+- Replace `include_enterprise` query parameter with `X-NC-Subscription-Key` header for retrieval of enterprise-only apps. #1848
 
 ## [4.12.0] - 2026-08-05
 

--- a/docs/api/restapi.rst
+++ b/docs/api/restapi.rst
@@ -268,9 +268,9 @@ This route will return all releases to display inside Nextcloud's apps admin are
 
   * **platform-version**: semantic version, core digits only: Returns all the apps and their releases that work on this version. If an app has no working releases, the app will be excluded
 
-* **Query parameters**:
+* **Headers**:
 
-  * **subscription_key**: string: Nextcloud Enterprise subscription key. If it is valid, enterprise-only apps will also be returned.
+  * **X-NC-Subscription-Key**: string: Nextcloud Enterprise subscription key. If it is valid, enterprise-only apps will also be returned.
 
 * **Authentication**: None
 
@@ -491,9 +491,9 @@ Get All Apps and Releases
 This route will return all releases to display inside Nextcloud's apps admin area.
 
 * **Url**: GET /api/v1/apps.json
-* **Query parameters**:
+* **Headers**:
 
-  * **subscription_key**: string: Nextcloud Enterprise subscription key. If it is valid, enterprise-only apps will also be returned.
+  * **X-NC-Subscription-Key**: string: Nextcloud Enterprise subscription key. If it is valid, enterprise-only apps will also be returned.
 
 * **Authentication**: None
 

--- a/nextcloudappstore/api/v1/tests/test_app.py
+++ b/nextcloudappstore/api/v1/tests/test_app.py
@@ -38,7 +38,7 @@ class AppTest(ApiTest):
         self._create_app_with_release("enterprise", is_enterprise_only=True)
         url = reverse("api:v1:apps")
         with patch("nextcloudappstore.core.enterprise.validate_subscription_key", return_value=False):
-            response = self.api_client.get(url, {"subscription_key": "invalid"})
+            response = self.api_client.get(url, HTTP_X_NC_SUBSCRIPTION_KEY="invalid")
         self.assertEqual(200, response.status_code)
         ids = [app["id"] for app in response.data]
         self.assertIn("news", ids)
@@ -49,7 +49,7 @@ class AppTest(ApiTest):
         self._create_app_with_release("enterprise", is_enterprise_only=True)
         url = reverse("api:v1:apps")
         with patch("nextcloudappstore.core.enterprise.validate_subscription_key", return_value=True):
-            response = self.api_client.get(url, {"subscription_key": "valid"})
+            response = self.api_client.get(url, HTTP_X_NC_SUBSCRIPTION_KEY="valid")
         self.assertEqual(200, response.status_code)
         ids = [app["id"] for app in response.data]
         self.assertIn("news", ids)
@@ -70,7 +70,7 @@ class AppTest(ApiTest):
         self._create_app_with_release("enterprise", is_enterprise_only=True)
         url = reverse("api:v1:app", kwargs={"version": "9.1.1"})
         with patch("nextcloudappstore.core.enterprise.validate_subscription_key", return_value=True):
-            response = self.api_client.get(url, {"subscription_key": "valid"})
+            response = self.api_client.get(url, HTTP_X_NC_SUBSCRIPTION_KEY="valid")
         self.assertEqual(200, response.status_code)
         ids = [app["id"] for app in response.data]
         self.assertIn("news", ids)
@@ -91,7 +91,7 @@ class AppTest(ApiTest):
         self._create_app_with_release("enterprise", is_enterprise_only=True, aa_is_system=False)
         url = reverse("api:v1:appapi_apps")
         with patch("nextcloudappstore.core.enterprise.validate_subscription_key", return_value=True):
-            response = self.api_client.get(url, {"subscription_key": "valid"})
+            response = self.api_client.get(url, HTTP_X_NC_SUBSCRIPTION_KEY="valid")
         self.assertEqual(200, response.status_code)
         ids = [app["id"] for app in response.data]
         self.assertIn("news", ids)

--- a/nextcloudappstore/core/enterprise.py
+++ b/nextcloudappstore/core/enterprise.py
@@ -40,7 +40,7 @@ def validate_subscription_key(subscription_key: str) -> bool:
 
 def enterprise_enabled(request) -> bool:
     if not hasattr(request, "_enterprise_enabled"):
-        subscription_key = request.GET.get("subscription_key", "")
+        subscription_key = request.headers.get("X-NC-Subscription-Key", "")
         request._enterprise_enabled = validate_subscription_key(subscription_key)
     return request._enterprise_enabled
 

--- a/nextcloudappstore/core/tests/test_caching.py
+++ b/nextcloudappstore/core/tests/test_caching.py
@@ -57,8 +57,8 @@ class AppsCachingTestBase(TestCase):
         self.app = App.objects.create(id="news", owner=self.user, last_release=self.t1)
 
     def _request(self, subscription_key=None):
-        data = {"subscription_key": subscription_key} if subscription_key is not None else {}
-        return self.factory.get("/apps.json", data)
+        kwargs = {"HTTP_X_NC_SUBSCRIPTION_KEY": subscription_key} if subscription_key is not None else {}
+        return self.factory.get("/apps.json", **kwargs)
 
     def _create_enterprise_app(self):
         t2 = self.t1 + datetime.timedelta(hours=1)

--- a/nextcloudappstore/settings/base.py
+++ b/nextcloudappstore/settings/base.py
@@ -219,6 +219,7 @@ CORS_ALLOW_HEADERS = (
     "origin",
     "authorization",
     "if-none-match",
+    "x-nc-subscription-key",
 )
 CORS_EXPOSE_HEADERS = (
     "etag",


### PR DESCRIPTION
Follows the convention used in the NC server, e.g. https://github.com/nextcloud/server/blob/fce0e3cbdd7328d6265109d881b44c09a923f040/lib/private/App/AppStore/Fetcher/Fetcher.php#L94

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
